### PR TITLE
Add `is_bot` field to user records

### DIFF
--- a/backend/canisters/user_index/api/src/queries/c2c_lookup_principal.rs
+++ b/backend/canisters/user_index/api/src/queries/c2c_lookup_principal.rs
@@ -16,5 +16,6 @@ pub enum Response {
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct SuccessResult {
     pub principal: Principal,
+    pub is_bot: bool,
     pub is_super_admin: bool,
 }

--- a/backend/canisters/user_index/impl/src/model/user.rs
+++ b/backend/canisters/user_index/impl/src/model/user.rs
@@ -149,6 +149,7 @@ impl Default for User {
             open_storage_limit_bytes: 0,
             phone_status: PhoneStatus::None,
             referred_by: None,
+            is_bot: false,
         }
     }
 }

--- a/backend/canisters/user_index/impl/src/model/user.rs
+++ b/backend/canisters/user_index/impl/src/model/user.rs
@@ -20,6 +20,8 @@ pub struct User {
     pub open_storage_limit_bytes: u64,
     pub phone_status: PhoneStatus,
     pub referred_by: Option<UserId>,
+    #[serde(default)]
+    pub is_bot: bool,
 }
 
 impl User {
@@ -71,6 +73,7 @@ impl User {
         now: TimestampMillis,
         wasm_version: Version,
         referred_by: Option<UserId>,
+        is_bot: bool,
     ) -> User {
         User {
             principal,
@@ -88,6 +91,7 @@ impl User {
             open_storage_limit_bytes: 0,
             phone_status: PhoneStatus::None,
             referred_by,
+            is_bot,
         }
     }
 
@@ -100,6 +104,7 @@ impl User {
             username: self.username.clone(),
             seconds_since_last_online,
             avatar_id: self.avatar_id,
+            is_bot: self.is_bot,
         }
     }
 
@@ -112,6 +117,7 @@ impl User {
             username: if include_username { Some(self.username.clone()) } else { None },
             seconds_since_last_online,
             avatar_id: self.avatar_id,
+            is_bot: self.is_bot,
         }
     }
 }

--- a/backend/canisters/user_index/impl/src/model/user_map.rs
+++ b/backend/canisters/user_index/impl/src/model/user_map.rs
@@ -388,6 +388,7 @@ impl UserMap {
             user.username.clone(),
             user.date_created,
             None,
+            false,
         );
         self.update(user);
     }
@@ -447,9 +448,9 @@ mod tests {
         let user_id2: UserId = Principal::from_slice(&[3, 2]).into();
         let user_id3: UserId = Principal::from_slice(&[3, 3]).into();
 
-        user_map.register(principal1, user_id1, Version::new(0, 0, 0), username1.clone(), 1, None);
-        user_map.register(principal2, user_id2, Version::new(0, 0, 0), username2.clone(), 2, None);
-        user_map.register(principal3, user_id3, Version::new(0, 0, 0), username3.clone(), 3, None);
+        user_map.register(principal1, user_id1, Version::new(0, 0, 0), username1.clone(), 1, None, false);
+        user_map.register(principal2, user_id2, Version::new(0, 0, 0), username2.clone(), 2, None, false);
+        user_map.register(principal3, user_id3, Version::new(0, 0, 0), username3.clone(), 3, None, false);
         user_map.submit_phone_number(principal3, phone_number3.clone(), "123".to_string(), 4);
 
         let phone_number_to_user_id: Vec<_> = user_map
@@ -495,9 +496,9 @@ mod tests {
 
         let phone_number = PhoneNumber::new(44, "1111 111 111".to_owned());
 
-        user_map.register(principal1, user_id1, Version::new(0, 0, 0), "1".to_string(), 1, None);
+        user_map.register(principal1, user_id1, Version::new(0, 0, 0), "1".to_string(), 1, None, false);
         user_map.submit_phone_number(principal1, phone_number.clone(), "123".to_string(), 2);
-        user_map.register(principal2, user_id2, Version::new(0, 0, 0), "2".to_string(), 3, None);
+        user_map.register(principal2, user_id2, Version::new(0, 0, 0), "2".to_string(), 3, None, false);
 
         assert!(matches!(
             user_map.submit_phone_number(principal2, phone_number, "123".to_string(), 4),
@@ -518,7 +519,7 @@ mod tests {
 
         let user_id = Principal::from_slice(&[1, 1]).into();
 
-        user_map.register(principal, user_id, Version::new(0, 0, 0), username1, 1, None);
+        user_map.register(principal, user_id, Version::new(0, 0, 0), username1, 1, None, false);
         user_map.submit_phone_number(principal, phone_number1, "123".to_string(), 2);
 
         if let Some(original) = user_map.get_by_principal(&principal) {

--- a/backend/canisters/user_index/impl/src/model/user_map.rs
+++ b/backend/canisters/user_index/impl/src/model/user_map.rs
@@ -75,6 +75,7 @@ impl UserMap {
         self.reserved_usernames.remove(username);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn register(
         &mut self,
         principal: Principal,

--- a/backend/canisters/user_index/impl/src/model/user_map.rs
+++ b/backend/canisters/user_index/impl/src/model/user_map.rs
@@ -83,11 +83,12 @@ impl UserMap {
         username: String,
         now: TimestampMillis,
         referred_by: Option<UserId>,
+        is_bot: bool,
     ) {
         self.username_to_user_id.insert(&username, user_id);
         self.principal_to_user_id.insert(principal, user_id);
 
-        let user = User::new(principal, user_id, username, now, wasm_version, referred_by);
+        let user = User::new(principal, user_id, username, now, wasm_version, referred_by, is_bot);
         self.users.insert(user_id, user);
 
         if let Some(ref_by) = referred_by {

--- a/backend/canisters/user_index/impl/src/queries/c2c_lookup_principal.rs
+++ b/backend/canisters/user_index/impl/src/queries/c2c_lookup_principal.rs
@@ -13,6 +13,7 @@ fn c2c_lookup_principal_impl(args: Args, runtime_state: &RuntimeState) -> Respon
 
         Success(SuccessResult {
             principal: user.principal,
+            is_bot: user.is_bot,
             is_super_admin,
         })
     } else {

--- a/backend/canisters/user_index/impl/src/updates/register_user.rs
+++ b/backend/canisters/user_index/impl/src/updates/register_user.rs
@@ -136,7 +136,7 @@ fn commit(
     runtime_state
         .data
         .users
-        .register(caller, user_id, wasm_version, username.clone(), now, referred_by);
+        .register(caller, user_id, wasm_version, username.clone(), now, referred_by, false);
 
     if let Some(referred_by) = referred_by {
         runtime_state.data.user_event_sync_queue.push(

--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -548,6 +548,7 @@ type PartialUserSummary =
         username: opt text;
         seconds_since_last_online: nat32;
         avatar_id: opt nat;
+        is_bot: bool;
     };
 
 type Participant =
@@ -823,6 +824,7 @@ type UserSummary =
         username: text;
         seconds_since_last_online: nat32;
         avatar_id: opt nat;
+        is_bot: bool;
     };
 
 type Version =

--- a/backend/libraries/types/src/user_summary.rs
+++ b/backend/libraries/types/src/user_summary.rs
@@ -8,6 +8,7 @@ pub struct UserSummary {
     pub username: String,
     pub seconds_since_last_online: u32,
     pub avatar_id: Option<u128>,
+    pub is_bot: bool,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
@@ -16,4 +17,5 @@ pub struct PartialUserSummary {
     pub username: Option<String>,
     pub seconds_since_last_online: u32,
     pub avatar_id: Option<u128>,
+    pub is_bot: bool,
 }


### PR DESCRIPTION
When creating a group we now query the user_index to verify that the caller is a valid OpenChat user.
This means the ProposalsBot needs to exist as a user in the user_index, otherwise it won't be able to create new groups.
This PR simply adds an `is_bot` field to each user record.
I'll create a follow on PR to register the ProposalsBot which will make use of that new field.