### PR TITLE
Register the ProposalsBot during user_index initialization

### DIFF
--- a/backend/canisters/user_index/api/src/lifecycle/init.rs
+++ b/backend/canisters/user_index/api/src/lifecycle/init.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
-use types::{CanisterId, CanisterWasm, Version};
+use types::{CanisterId, CanisterWasm, UserId, Version};
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct Args {
@@ -24,6 +24,8 @@ pub struct Args {
     pub open_storage_index_canister_id: CanisterId,
 
     pub ledger_canister_id: CanisterId,
+
+    pub proposals_bot_user_id: UserId,
 
     pub wasm_version: Version,
 

--- a/backend/canisters/user_index/impl/src/lib.rs
+++ b/backend/canisters/user_index/impl/src/lib.rs
@@ -153,11 +153,25 @@ impl Data {
         callback_canister_id: CanisterId,
         open_storage_index_canister_id: CanisterId,
         ledger_canister_id: CanisterId,
+        proposals_bot_user_id: UserId,
         canister_pool_target_size: u16,
         test_mode: bool,
     ) -> Self {
+        let mut users = UserMap::default();
+
+        // Register the ProposalsBot
+        users.register(
+            proposals_bot_user_id.into(),
+            proposals_bot_user_id,
+            user_canister_wasm.version,
+            "ProposalsBot".to_string(),
+            0,
+            None,
+            true,
+        );
+
         Data {
-            users: UserMap::default(),
+            users,
             service_principals: service_principals.into_iter().collect(),
             user_canister_wasm,
             sms_service_principals: sms_service_principals.into_iter().collect(),

--- a/backend/canisters/user_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/init.rs
@@ -27,6 +27,7 @@ fn init(args: Args) {
         args.callback_canister_id,
         args.open_storage_index_canister_id,
         args.ledger_canister_id,
+        args.proposals_bot_user_id,
         canister_pool_target_size,
         args.test_mode,
     );

--- a/backend/libraries/canister_client/src/operations/install_service_canisters.rs
+++ b/backend/libraries/canister_client/src/operations/install_service_canisters.rs
@@ -102,6 +102,7 @@ async fn install_service_canisters_impl(
         callback_canister_id: canister_ids.callback,
         open_storage_index_canister_id: canister_ids.open_storage_index,
         ledger_canister_id: canister_ids.ledger,
+        proposals_bot_user_id: canister_ids.proposals_bot.into(),
         wasm_version: version,
         test_mode,
     };


### PR DESCRIPTION
Up until now the ProposalsBot's user record has been hardcoded in the frontend and hasn't existed in the backend, but it now also needs to exist in the backend because we've started verifying users when they try to create groups.

So the ProposalsBot needs to be registered as a user when we initialize the service.