### PR TITLE
Scroll to latest message rather than bottom of window

### DIFF
--- a/frontend/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/src/components/home/CurrentChatMessages.svelte
@@ -960,7 +960,7 @@
     class="fab to-bottom"
     class:footer
     class:rtl={$rtlStore}>
-    <Fab on:click={() => scrollBottom()}>
+    <Fab on:click={() => scrollToMessageIndex(chat.latestMessage.event.messageIndex, false)}>
         {#if unreadMessages > 0}
             <div in:pop={{ duration: 1500 }} class="unread">
                 <div class="unread-count">{unreadMessages > 999 ? "999+" : unreadMessages}</div>

--- a/frontend/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/src/components/home/CurrentChatMessages.svelte
@@ -960,7 +960,7 @@
     class="fab to-bottom"
     class:footer
     class:rtl={$rtlStore}>
-    <Fab on:click={() => scrollToMessageIndex(chat.latestMessage.event.messageIndex, false)}>
+    <Fab on:click={() => scrollToMessageIndex(chat.latestMessage?.event.messageIndex ?? -1, false)}>
         {#if unreadMessages > 0}
             <div in:pop={{ duration: 1500 }} class="unread">
                 <div class="unread-count">{unreadMessages > 999 ? "999+" : unreadMessages}</div>


### PR DESCRIPTION
The 'Go to bottom' button was only scrolling to the bottom of the currently loaded window, whereas it should always jump you to the latest message.