### PR TITLE
Fix unread message count

### DIFF
--- a/frontend/src/components/home/CurrentChat.svelte
+++ b/frontend/src/components/home/CurrentChat.svelte
@@ -9,7 +9,6 @@
         canInviteUsers,
         canReplyInThread,
         getFirstUnreadMention,
-        getFirstUnreadMessageIndex,
         getMessageContent,
         getMinVisibleMessageIndex,
         markAllRead,
@@ -73,7 +72,6 @@
     $: chatId = chat.chatId;
     let previousChatId: string | undefined = undefined;
     let unreadMessages = 0;
-    let firstUnreadMessage: number | undefined;
     let firstUnreadMention: Mention | undefined;
     let creatingPoll = false;
     let creatingCryptoTransfer: { token: Cryptocurrency; amount: bigint } | undefined = undefined;
@@ -94,7 +92,6 @@
             showSearchHeader = false;
             unreadMessages = getUnreadMessageCount(chat);
             firstUnreadMention = getFirstUnreadMention(chat);
-            firstUnreadMessage = getFirstUnreadMessageIndex(chat);
 
             tick().then(() => {
                 if ($messageToForwardStore !== undefined) {
@@ -108,7 +105,6 @@
     let unsub = messagesRead.subscribe(() => {
         unreadMessages = getUnreadMessageCount(chat);
         firstUnreadMention = getFirstUnreadMention(chat);
-        firstUnreadMessage = getFirstUnreadMessageIndex(chat);
     });
 
     function getUnreadMessageCount(chat: ChatSummary): number {
@@ -295,7 +291,6 @@
         canInvite={canInviteUsers(chat)}
         {preview}
         {firstUnreadMention}
-        {firstUnreadMessage}
         footer={showFooter}
         {unreadMessages} />
     {#if showFooter}

--- a/frontend/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/src/components/home/CurrentChatMessages.svelte
@@ -110,7 +110,6 @@
     export let unreadMessages: number;
     export let preview: boolean;
     export let firstUnreadMention: Mention | undefined;
-    export let firstUnreadMessage: number | undefined;
     export let canPin: boolean;
     export let canBlockUser: boolean;
     export let canDelete: boolean;

--- a/frontend/src/stores/markRead.ts
+++ b/frontend/src/stores/markRead.ts
@@ -231,15 +231,19 @@ export class MessageReadTracker {
             return 0;
         }
 
-        const serverState = this.serverState[chatId]?.ranges.clone() ?? new DRange();
+        const messagesRead = new DRange();
+        const serverState = this.serverState[chatId]?.ranges ?? new DRange();
+        const localState = this.state[chatId]?.ranges ?? new DRange();
+
+        messagesRead.add(serverState).add(localState);
+
         // Exclude any data for messages earlier than the `firstMessageIndex`
         if (firstMessageIndex > 0) {
-            serverState.subtract(new DRange(0, firstMessageIndex - 1));
+            messagesRead.subtract(new DRange(0, firstMessageIndex - 1));
         }
         const total = latestMessageIndex - firstMessageIndex + 1;
         const read =
-            serverState.length +
-            (this.state[chatId]?.ranges?.length ?? 0) +
+            messagesRead.length +
             (this.waiting[chatId]?.size ?? 0);
         return Math.max(total - read, 0);
     }

--- a/frontend/src/stores/markRead.ts
+++ b/frontend/src/stores/markRead.ts
@@ -231,11 +231,10 @@ export class MessageReadTracker {
             return 0;
         }
 
-        const messagesRead = new DRange();
         const serverState = this.serverState[chatId]?.ranges ?? new DRange();
         const localState = this.state[chatId]?.ranges ?? new DRange();
 
-        messagesRead.add(serverState).add(localState);
+        const messagesRead = new DRange().add(serverState).add(localState);
 
         // Exclude any data for messages earlier than the `firstMessageIndex`
         if (firstMessageIndex > 0) {

--- a/frontend/src/stores/markRead.ts
+++ b/frontend/src/stores/markRead.ts
@@ -154,12 +154,11 @@ export class MessageReadTracker {
                 this.waiting[chatId] = new Map<bigint, number>();
             }
             this.waiting[chatId].set(messageId, messageIndex);
+            this.publish();
         } else {
             // Mark the chat as read up to the new messageIndex
             this.markRangeRead(chatId, 0, messageIndex);
         }
-
-        this.publish();
     }
 
     markRangeRead(chatId: string, from: number, to: number): void {

--- a/frontend/src/stores/markRead.ts
+++ b/frontend/src/stores/markRead.ts
@@ -240,10 +240,9 @@ export class MessageReadTracker {
         if (firstMessageIndex > 0) {
             messagesRead.subtract(new DRange(0, firstMessageIndex - 1));
         }
+
         const total = latestMessageIndex - firstMessageIndex + 1;
-        const read =
-            messagesRead.length +
-            (this.waiting[chatId]?.size ?? 0);
+        const read = messagesRead.length + (this.waiting[chatId]?.size ?? 0);
         return Math.max(total - read, 0);
     }
 


### PR DESCRIPTION
The unread message count was double counting in some scenarios because we now mark read from 0 -> N, meaning the server state could be 0 -> N _and_ the local state could be 0 -> N, and we weren't accounting for this when determining how many messages are unread.