### PR TITLE
a few changes to do with how users are loaded and cached

### DIFF
--- a/frontend/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/src/components/home/CurrentChatMessages.svelte
@@ -572,9 +572,12 @@
             initialised = false;
 
             if ($focusMessageIndex !== undefined) {
-                loadEventWindow(api, user, serverChat, chat, $focusMessageIndex)
-                    .then(onMessageWindowLoaded)
-                    .then(() => loadDetails(api, user, chat, events));
+                loadEventWindow(api, user, serverChat, chat, $focusMessageIndex).then(
+                    (messageIndex: number | undefined) => {
+                        loadDetails(api, user, chat, events);
+                        onMessageWindowLoaded(messageIndex);
+                    }
+                );
             } else {
                 loadPreviousMessages(api, user, serverChat, chat).then(() => {
                     loadDetails(api, user, chat, events);

--- a/frontend/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/src/components/home/CurrentChatMessages.svelte
@@ -572,13 +572,15 @@
             initialised = false;
 
             if ($focusMessageIndex !== undefined) {
-                loadEventWindow(api, user, serverChat, chat, $focusMessageIndex).then(
-                    onMessageWindowLoaded
-                );
+                loadEventWindow(api, user, serverChat, chat, $focusMessageIndex)
+                    .then(onMessageWindowLoaded)
+                    .then(() => loadDetails(api, user, chat, events));
             } else {
-                loadPreviousMessages(api, user, serverChat, chat).then(onLoadedPreviousMessages);
+                loadPreviousMessages(api, user, serverChat, chat).then(() => {
+                    loadDetails(api, user, chat, events);
+                    onLoadedPreviousMessages();
+                });
             }
-            loadDetails(api, user, chat, events);
         }
     }
 

--- a/frontend/src/components/home/Home.svelte
+++ b/frontend/src/components/home/Home.svelte
@@ -290,7 +290,6 @@
                 history.replaceState(null, "", "/#/");
                 modal = ModalType.SelectChat;
             } else {
-                console.log("XX: routeChange: ", pathParams.chatId);
                 // if we have something in the chatId url param
 
                 // first close any open thread

--- a/frontend/src/components/home/Home.svelte
+++ b/frontend/src/components/home/Home.svelte
@@ -290,6 +290,7 @@
                 history.replaceState(null, "", "/#/");
                 modal = ModalType.SelectChat;
             } else {
+                console.log("XX: routeChange: ", pathParams.chatId);
                 // if we have something in the chatId url param
 
                 // first close any open thread

--- a/frontend/src/services/common/chatThread.ts
+++ b/frontend/src/services/common/chatThread.ts
@@ -336,7 +336,8 @@ export async function handleEventsResponse(
     // Only include affected events that overlap with already loaded events
     const confirmedLoaded = confirmedEventIndexesLoaded(chat.chatId);
     const events = resp.events.concat(
-        resp.affectedEvents.filter((e) => indexIsInRanges(e.index, confirmedLoaded)));
+        resp.affectedEvents.filter((e) => indexIsInRanges(e.index, confirmedLoaded))
+    );
 
     const userIds = userIdsFromEvents(events);
     await updateUserStore(api, chat.chatId, user.userId, userIds);
@@ -743,7 +744,8 @@ export async function handleMessageSentByOther(
         });
     } else {
         const existing = currentEvents.find(
-            (ev) => ev.event.kind === "message" && ev.event.messageId === messageEvent.event.messageId
+            (ev) =>
+                ev.event.kind === "message" && ev.event.messageId === messageEvent.event.messageId
         );
         if (existing === undefined) {
             unconfirmed.add(clientChat.chatId, messageEvent);
@@ -825,7 +827,11 @@ export function sendMessageWithAttachment(
     return sendMessage(api, user, serverChat, clientChat, currentEvents, evt);
 }
 
-function onSendMessageSuccess(chatId: string, resp: SendMessageSuccess | TransferSuccess, msg: Message) {
+function onSendMessageSuccess(
+    chatId: string,
+    resp: SendMessageSuccess | TransferSuccess,
+    msg: Message
+) {
     const event = mergeSendMessageResponse(msg, resp);
 
     addServerEventsToStores(chatId, [event]);

--- a/frontend/src/services/serviceContainer.ts
+++ b/frontend/src/services/serviceContainer.ts
@@ -141,7 +141,7 @@ export class ServiceContainer implements MarkMessagesRead {
         this.db = initDb(identity.getPrincipal().toString());
         this.userdb = initUserDb();
         this._onlineClient = OnlineClient.create(identity);
-        this._userIndexClient = UserIndexClient.create(identity, this.db, this.userdb);
+        this._userIndexClient = UserIndexClient.create(identity, this.userdb);
         this._groupIndexClient = GroupIndexClient.create(identity);
         this._notificationClient = NotificationsClient.create(identity);
         this._ledgerClients = {
@@ -167,7 +167,13 @@ export class ServiceContainer implements MarkMessagesRead {
     }
 
     createUserClient(userId: string): ServiceContainer {
-        this._userClient = UserClient.create(userId, this.identity, this.db, this._groupInvite);
+        this._userClient = UserClient.create(
+            userId,
+            this.identity,
+            this.db,
+            this.userdb,
+            this._groupInvite
+        );
         return this;
     }
 
@@ -1066,14 +1072,14 @@ export class ServiceContainer implements MarkMessagesRead {
 
     getBio(userId?: string): Promise<string> {
         const userClient = userId
-            ? UserClient.create(userId, this.identity, undefined, undefined)
+            ? UserClient.create(userId, this.identity, this.db, this.userdb, undefined)
             : this.userClient;
         return userClient.getBio();
     }
 
     getPublicProfile(userId?: string): Promise<PublicProfile> {
         const userClient = userId
-            ? UserClient.create(userId, this.identity, undefined, undefined)
+            ? UserClient.create(userId, this.identity, this.db, this.userdb, undefined)
             : this.userClient;
         return userClient.getPublicProfile();
     }
@@ -1201,7 +1207,13 @@ export class ServiceContainer implements MarkMessagesRead {
     }
 
     migrateUserPrincipal(userId: string): Promise<MigrateUserPrincipalResponse> {
-        const userClient = UserClient.create(userId, this.identity, undefined, undefined);
+        const userClient = UserClient.create(
+            userId,
+            this.identity,
+            this.db,
+            this.userdb,
+            undefined
+        );
         return userClient.migrateUserPrincipal();
     }
 

--- a/frontend/src/services/user/user.caching.client.ts
+++ b/frontend/src/services/user/user.caching.client.ts
@@ -28,6 +28,7 @@ import type {
 import type { IUserClient } from "./user.client.interface";
 import {
     ChatSchema,
+    Database,
     getCachedChats,
     getCachedEvents,
     getCachedEventsByIndex,
@@ -76,6 +77,7 @@ import { rollbar } from "../../utils/logging";
 import type { GroupInvite } from "../../services/serviceContainer";
 import type { ServiceRetryInterrupt } from "services/candidService";
 import { configKeys } from "../../utils/config";
+import type { UserDatabase } from "../../utils/userCache";
 
 /**
  * This exists to decorate the user client so that we can provide a write through cache to
@@ -87,7 +89,8 @@ export class CachingUserClient implements IUserClient {
     }
 
     constructor(
-        private db: Promise<IDBPDatabase<ChatSchema>>,
+        private db: Database,
+        private userdb: UserDatabase,
         private identity: Identity,
         private client: IUserClient,
         private groupInvite: GroupInvite | undefined
@@ -264,11 +267,7 @@ export class CachingUserClient implements IUserClient {
         for (const batch of chunk(orderedChats, batchSize)) {
             const eventsPromises = batch.map((chat) => {
                 // horrible having to do this but if we don't the message read tracker will not be in the right state
-                messagesRead.syncWithServer(
-                    chat.chatId,
-                    chat.readByMe,
-                    threadsReadFromChat(chat)
-                );
+                messagesRead.syncWithServer(chat.chatId, chat.readByMe, threadsReadFromChat(chat));
 
                 const targetMessageIndex = getFirstUnreadMessageIndex(chat);
                 const range = indexRangeForChat(chat);
@@ -336,7 +335,7 @@ export class CachingUserClient implements IUserClient {
 
                     const missing = missingUserIds(get(userStore), userIds);
                     if (missing.length > 0) {
-                        return UserIndexClient.create(this.identity, this.db).getUsers(
+                        return UserIndexClient.create(this.identity, this.userdb).getUsers(
                             {
                                 userGroups: [
                                     {
@@ -474,7 +473,13 @@ export class CachingUserClient implements IUserClient {
         username: string,
         threadRootMessageIndex?: number
     ): Promise<AddRemoveReactionResponse> {
-        return this.client.addReaction(otherUserId, messageId, reaction, username, threadRootMessageIndex);
+        return this.client.addReaction(
+            otherUserId,
+            messageId,
+            reaction,
+            username,
+            threadRootMessageIndex
+        );
     }
 
     removeReaction(

--- a/frontend/src/services/userIndex/userIndex.client.ts
+++ b/frontend/src/services/userIndex/userIndex.client.ts
@@ -33,7 +33,7 @@ import {
 } from "./mappers";
 import { CachingUserIndexClient } from "./userIndex.caching.client";
 import type { IUserIndexClient } from "./userIndex.client.interface";
-import { cachingLocallyDisabled, Database } from "../../utils/caching";
+import { cachingLocallyDisabled } from "../../utils/caching";
 import { profile } from "../common/profiling";
 import { apiOptional } from "../common/chatMappers";
 import type { UserDatabase } from "../../utils/userCache";
@@ -51,8 +51,8 @@ export class UserIndexClient extends CandidService implements IUserIndexClient {
         );
     }
 
-    static create(identity: Identity, db?: Database, userdb?: UserDatabase): IUserIndexClient {
-        return db && userdb && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
+    static create(identity: Identity, userdb?: UserDatabase): IUserIndexClient {
+        return userdb && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
             ? new CachingUserIndexClient(userdb, new UserIndexClient(identity))
             : new UserIndexClient(identity);
     }

--- a/frontend/src/services/userIndex/userIndex.client.ts
+++ b/frontend/src/services/userIndex/userIndex.client.ts
@@ -36,6 +36,7 @@ import type { IUserIndexClient } from "./userIndex.client.interface";
 import { cachingLocallyDisabled, Database } from "../../utils/caching";
 import { profile } from "../common/profiling";
 import { apiOptional } from "../common/chatMappers";
+import type { UserDatabase } from "../../utils/userCache";
 
 export class UserIndexClient extends CandidService implements IUserIndexClient {
     private userService: UserIndexService;
@@ -50,9 +51,9 @@ export class UserIndexClient extends CandidService implements IUserIndexClient {
         );
     }
 
-    static create(identity: Identity, db?: Database): IUserIndexClient {
-        return db && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
-            ? new CachingUserIndexClient(db, new UserIndexClient(identity))
+    static create(identity: Identity, db?: Database, userdb?: UserDatabase): IUserIndexClient {
+        return db && userdb && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
+            ? new CachingUserIndexClient(userdb, new UserIndexClient(identity))
             : new UserIndexClient(identity);
     }
 

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -151,10 +151,7 @@ export function nextEventAndMessageIndexes(): [number, number] {
     if (chat === undefined) {
         return [0, 0];
     }
-    return getNextEventAndMessageIndexes(
-        chat,
-        unconfirmed.getMessages(chat.chatId)
-    );
+    return getNextEventAndMessageIndexes(chat, unconfirmed.getMessages(chat.chatId));
 }
 
 export const isProposalGroup = derived([selectedChatStore], ([$selectedChat]) => {
@@ -278,12 +275,10 @@ const confirmedEventIndexesLoadedStore = derived([serverEventsStore], ([serverEv
     const ranges = new DRange();
     serverEvents.forEach((e) => ranges.add(e.index));
     return ranges;
-})
+});
 
 export function confirmedEventIndexesLoaded(chatId: string): DRange {
-    return get(selectedChatId) === chatId
-        ? get(confirmedEventIndexesLoadedStore)
-        : new DRange();
+    return get(selectedChatId) === chatId ? get(confirmedEventIndexesLoadedStore) : new DRange();
 }
 
 export const currentChatRules = createDerivedPropStore<ChatSpecificState, "rules">(

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -43,13 +43,11 @@ const { subscribe, update, set } = immutableStore<UserLookup>({
 });
 
 export function overwriteUser(lookup: UserLookup, user: PartialUserSummary): UserLookup {
-    return {
-        ...lookup,
-        [user.userId]: {
-            ...user,
-            username: user.username ?? lookup[user.userId]?.username,
-        },
+    lookup[user.userId] = {
+        ...user,
+        username: user.username ?? lookup[user.userId]?.username,
     };
+    return lookup;
 }
 
 export const userStore = {
@@ -60,11 +58,15 @@ export const userStore = {
         set(users);
     },
     add: (user: PartialUserSummary): void => {
-        update((users) => overwriteUser(users, user));
+        update((users) => {
+            const clone = { ...users };
+            return overwriteUser(clone, user);
+        });
     },
     addMany: (newUsers: PartialUserSummary[]): void => {
         update((users) => {
-            return newUsers.reduce((lookup, user) => overwriteUser(lookup, user), users);
+            const clone = { ...users };
+            return newUsers.reduce((lookup, user) => overwriteUser(lookup, user), clone);
         });
     },
     setUpdated: (userIds: string[], timestamp: bigint): void => {

--- a/frontend/src/utils/caching.ts
+++ b/frontend/src/utils/caching.ts
@@ -19,7 +19,7 @@ import type {
 import { rollbar } from "./logging";
 import { UnsupportedValueError } from "./error";
 
-const CACHE_VERSION = 45;
+const CACHE_VERSION = 46;
 
 export type Database = Promise<IDBPDatabase<ChatSchema>>;
 

--- a/frontend/src/utils/userCache.ts
+++ b/frontend/src/utils/userCache.ts
@@ -1,0 +1,95 @@
+import { openDB, DBSchema, IDBPDatabase } from "idb";
+import type { UserSummary } from "../domain/user/user";
+import { rollbar } from "./logging";
+
+const CACHE_VERSION = 1;
+
+export type UserDatabase = Promise<IDBPDatabase<UserSchema>>;
+
+export interface UserSchema extends DBSchema {
+    users: {
+        key: string;
+        value: UserSummary;
+    };
+}
+
+export function cachingLocallyDisabled(): boolean {
+    return !!localStorage.getItem("openchat_nocache");
+}
+
+export function openUserCache(): UserDatabase | undefined {
+    if (process.env.NODE_ENV === "test" || !process.env.CLIENT_CACHING) {
+        return undefined;
+    }
+    try {
+        return openDB<UserSchema>(`openchat_users`, CACHE_VERSION, {
+            upgrade(db, _oldVersion, _newVersion, _transaction) {
+                try {
+                    if (db.objectStoreNames.contains("users")) {
+                        db.deleteObjectStore("users");
+                    }
+                    db.createObjectStore("users");
+                } catch (err) {
+                    rollbar.error("Unable to upgrade indexedDB for users", err as Error);
+                }
+            },
+        });
+    } catch (err) {
+        rollbar.error("Unable to open indexedDB for users", err as Error);
+    }
+}
+
+export async function getCachedUsers(db: UserDatabase, userIds: string[]): Promise<UserSummary[]> {
+    const resolvedDb = await db;
+
+    const fromCache = await Promise.all(userIds.map((u) => resolvedDb.get("users", u)));
+
+    return fromCache.reduce((users, next) => {
+        if (next !== undefined) users.push(next);
+        return users;
+    }, [] as UserSummary[]);
+}
+
+export async function getAllUsers(db: UserDatabase): Promise<UserSummary[]> {
+    return (await db).getAll("users");
+}
+
+export async function setCachedUsers(db: UserDatabase, users: UserSummary[]): Promise<void> {
+    if (users.length === 0) return;
+
+    const tx = (await db).transaction("users", "readwrite", { durability: "relaxed" });
+    const store = tx.objectStore("users");
+
+    await Promise.all(users.map((u) => store.put(u, u.userId)));
+    await tx.done;
+}
+
+export async function setUsername(
+    db: UserDatabase,
+    userId: string,
+    username: string
+): Promise<void> {
+    const tx = (await db).transaction("users", "readwrite", { durability: "relaxed" });
+    const store = tx.objectStore("users");
+    const user = await store.get(userId);
+    if (user !== undefined) {
+        user.username = username;
+        await store.put(user, userId);
+    }
+    await tx.done;
+}
+
+let db: UserDatabase | undefined;
+
+export function getDb(): UserDatabase | undefined {
+    return db;
+}
+
+export function initUserDb(): UserDatabase | undefined {
+    db = openUserCache();
+    return db;
+}
+
+export function closeDb(): void {
+    db = undefined;
+}


### PR DESCRIPTION
There are a few changes here:
 
1) staggering the loading of group details and previous events
2) splitting users into their own indexeddb since they rarely need to be ditched
3) vastly improve the efficiency of adding users to the user store (this makes by far the most difference)

Experimented with local storage which _is_ a good deal faster but a) it's sync and b) has limited capacity so isn't an ideal alternative. 