### PR TITLE
set cached users via service worker

### DIFF
--- a/frontend/rollup.config.js
+++ b/frontend/rollup.config.js
@@ -136,6 +136,7 @@ export default [
             replace({
                 preventAssignment: true,
                 "process.env.NODE_ENV": JSON.stringify(env),
+                "process.env.CLIENT_CACHING": process.env.CLIENT_CACHING,
                 "process.env.OPENCHAT_WEBSITE_VERSION": JSON.stringify(version),
             }),
 

--- a/frontend/src/services/serviceContainer.ts
+++ b/frontend/src/services/serviceContainer.ts
@@ -80,7 +80,7 @@ import type {
 } from "../domain/chat/chat";
 import type { IGroupClient } from "./group/group.client.interface";
 import { Database, initDb } from "../utils/caching";
-import { getAllUsers, initUserDb, UserDatabase } from "../utils/userCache";
+import { getAllUsers } from "../utils/userCache";
 import { UserIndexClient } from "./userIndex/userIndex.client";
 import { UserClient } from "./user/user.client";
 import { GroupClient } from "./group/group.client";
@@ -135,13 +135,11 @@ export class ServiceContainer implements MarkMessagesRead {
     private _groupClients: Record<string, IGroupClient>;
     private _groupInvite: GroupInvite | undefined;
     private db?: Database;
-    private userdb?: UserDatabase;
 
     constructor(private identity: Identity) {
         this.db = initDb(identity.getPrincipal().toString());
-        this.userdb = initUserDb();
         this._onlineClient = OnlineClient.create(identity);
-        this._userIndexClient = UserIndexClient.create(identity, this.userdb);
+        this._userIndexClient = UserIndexClient.create(identity);
         this._groupIndexClient = GroupIndexClient.create(identity);
         this._notificationClient = NotificationsClient.create(identity);
         this._ledgerClients = {
@@ -152,7 +150,7 @@ export class ServiceContainer implements MarkMessagesRead {
         this._groupClients = {};
         if (this.db) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            measure("getAllUsers", () => getAllUsers(this.userdb!)).then((users) => {
+            measure("getAllUsers", () => getAllUsers()).then((users) => {
                 const lookup = toRecord(
                     users.map((user) => this.rehydrateUserSummary(user)),
                     (u) => u.userId
@@ -167,13 +165,7 @@ export class ServiceContainer implements MarkMessagesRead {
     }
 
     createUserClient(userId: string): ServiceContainer {
-        this._userClient = UserClient.create(
-            userId,
-            this.identity,
-            this.db,
-            this.userdb,
-            this._groupInvite
-        );
+        this._userClient = UserClient.create(userId, this.identity, this.db, this._groupInvite);
         return this;
     }
 
@@ -1072,14 +1064,14 @@ export class ServiceContainer implements MarkMessagesRead {
 
     getBio(userId?: string): Promise<string> {
         const userClient = userId
-            ? UserClient.create(userId, this.identity, this.db, this.userdb, undefined)
+            ? UserClient.create(userId, this.identity, this.db, undefined)
             : this.userClient;
         return userClient.getBio();
     }
 
     getPublicProfile(userId?: string): Promise<PublicProfile> {
         const userClient = userId
-            ? UserClient.create(userId, this.identity, this.db, this.userdb, undefined)
+            ? UserClient.create(userId, this.identity, this.db, undefined)
             : this.userClient;
         return userClient.getPublicProfile();
     }
@@ -1207,13 +1199,7 @@ export class ServiceContainer implements MarkMessagesRead {
     }
 
     migrateUserPrincipal(userId: string): Promise<MigrateUserPrincipalResponse> {
-        const userClient = UserClient.create(
-            userId,
-            this.identity,
-            this.db,
-            this.userdb,
-            undefined
-        );
+        const userClient = UserClient.create(userId, this.identity, this.db, undefined);
         return userClient.migrateUserPrincipal();
     }
 

--- a/frontend/src/services/user/user.caching.client.ts
+++ b/frontend/src/services/user/user.caching.client.ts
@@ -27,7 +27,6 @@ import type {
 } from "../../domain/chat/chat";
 import type { IUserClient } from "./user.client.interface";
 import {
-    ChatSchema,
     Database,
     getCachedChats,
     getCachedEvents,
@@ -39,7 +38,6 @@ import {
     setCachedEvents,
     setCachedMessageFromSendResponse,
 } from "../../utils/caching";
-import type { IDBPDatabase } from "idb";
 import {
     compareChats,
     getFirstUnreadMessageIndex,
@@ -77,7 +75,6 @@ import { rollbar } from "../../utils/logging";
 import type { GroupInvite } from "../../services/serviceContainer";
 import type { ServiceRetryInterrupt } from "services/candidService";
 import { configKeys } from "../../utils/config";
-import type { UserDatabase } from "../../utils/userCache";
 
 /**
  * This exists to decorate the user client so that we can provide a write through cache to
@@ -90,7 +87,6 @@ export class CachingUserClient implements IUserClient {
 
     constructor(
         private db: Database,
-        private userdb: UserDatabase,
         private identity: Identity,
         private client: IUserClient,
         private groupInvite: GroupInvite | undefined
@@ -335,7 +331,7 @@ export class CachingUserClient implements IUserClient {
 
                     const missing = missingUserIds(get(userStore), userIds);
                     if (missing.length > 0) {
-                        return UserIndexClient.create(this.identity, this.userdb).getUsers(
+                        return UserIndexClient.create(this.identity).getUsers(
                             {
                                 userGroups: [
                                     {

--- a/frontend/src/services/user/user.client.ts
+++ b/frontend/src/services/user/user.client.ts
@@ -98,7 +98,6 @@ import { textToCode } from "../../domain/inviteCodes";
 import type { GroupInvite } from "../../services/serviceContainer";
 import { apiGroupRules } from "../group/mappers";
 import { generateUint64 } from "../../utils/rng";
-import type { UserDatabase } from "utils/userCache";
 
 export class UserClient extends CandidService implements IUserClient {
     private userService: UserService;
@@ -114,17 +113,10 @@ export class UserClient extends CandidService implements IUserClient {
         userId: string,
         identity: Identity,
         db: Database | undefined,
-        userdb: UserDatabase | undefined,
         groupInvite: GroupInvite | undefined
     ): IUserClient {
-        return db && userdb && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
-            ? new CachingUserClient(
-                  db,
-                  userdb,
-                  identity,
-                  new UserClient(identity, userId),
-                  groupInvite
-              )
+        return db && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
+            ? new CachingUserClient(db, identity, new UserClient(identity, userId), groupInvite)
             : new UserClient(identity, userId);
     }
 

--- a/frontend/src/services/userIndex/userIndex.caching.client.ts
+++ b/frontend/src/services/userIndex/userIndex.caching.client.ts
@@ -1,5 +1,4 @@
 import type { IUserIndexClient } from "./userIndex.client.interface";
-import type { Database } from "../../utils/caching";
 import type {
     ChallengeAttempt,
     CheckUsernameResponse,
@@ -21,20 +20,20 @@ import { groupBy } from "../../utils/list";
 import { isUserSummary } from "../../utils/user";
 import { profile } from "../common/profiling";
 import { rollbar } from "../../utils/logging";
-import { getCachedUsers, setCachedUsers, setUsername, UserDatabase } from "../../utils/userCache";
+import { getCachedUsers, setCachedUsers, setUsername } from "../../utils/userCache";
 
 /**
  * This exists to decorate the user index client so that we can provide a write through cache to
  * indexDB for holding users
  */
 export class CachingUserIndexClient implements IUserIndexClient {
-    constructor(private userdb: UserDatabase, private client: IUserIndexClient) {}
+    constructor(private client: IUserIndexClient) {}
 
     @profile("userIndexCachingClient")
     async getUsers(users: UsersArgs, allowStale: boolean): Promise<UsersResponse> {
         const allUsers = users.userGroups.flatMap((g) => g.users);
 
-        const fromCache = await getCachedUsers(this.userdb, allUsers);
+        const fromCache = await getCachedUsers(allUsers);
 
         // We throw away all of the updatedSince values passed in and instead use the values from the cache, this
         // ensures the cache is always correct and doesn't miss any updates
@@ -52,7 +51,7 @@ export class CachingUserIndexClient implements IUserIndexClient {
             fromCache
         );
 
-        setCachedUsers(this.userdb, mergedResponse.users.filter(isUserSummary)).catch((err) =>
+        setCachedUsers(mergedResponse.users.filter(isUserSummary)).catch((err) =>
             rollbar.error("Failed to save users to the cache", err)
         );
 
@@ -94,7 +93,7 @@ export class CachingUserIndexClient implements IUserIndexClient {
     setUsername(userId: string, username: string): Promise<SetUsernameResponse> {
         return this.client.setUsername(userId, username).then((res) => {
             if (res === "success") {
-                setUsername(this.userdb, userId, username);
+                setUsername(userId, username);
             }
             return res;
         });

--- a/frontend/src/services/userIndex/userIndex.client.ts
+++ b/frontend/src/services/userIndex/userIndex.client.ts
@@ -36,7 +36,6 @@ import type { IUserIndexClient } from "./userIndex.client.interface";
 import { cachingLocallyDisabled } from "../../utils/caching";
 import { profile } from "../common/profiling";
 import { apiOptional } from "../common/chatMappers";
-import type { UserDatabase } from "../../utils/userCache";
 
 export class UserIndexClient extends CandidService implements IUserIndexClient {
     private userService: UserIndexService;
@@ -51,9 +50,9 @@ export class UserIndexClient extends CandidService implements IUserIndexClient {
         );
     }
 
-    static create(identity: Identity, userdb?: UserDatabase): IUserIndexClient {
-        return userdb && process.env.CLIENT_CACHING && !cachingLocallyDisabled()
-            ? new CachingUserIndexClient(userdb, new UserIndexClient(identity))
+    static create(identity: Identity): IUserIndexClient {
+        return process.env.CLIENT_CACHING && !cachingLocallyDisabled()
+            ? new CachingUserIndexClient(new UserIndexClient(identity))
             : new UserIndexClient(identity);
     }
 


### PR DESCRIPTION
In addition to storing users in a separate indexeddb database, we will now attempt to do the bulk add in the service worker rather than in the main thread to further minimise the chance that it will interfere too much with the UI performance when large numbers of users need to be written to the cache. 