### PR TITLE
Prevent popstate closing modal

### DIFF
--- a/frontend/src/components/home/Home.svelte
+++ b/frontend/src/components/home/Home.svelte
@@ -322,7 +322,7 @@
                     }
 
                     if (!$mobileWidth && hotGroups.kind === "idle") {
-                        whatsHot();
+                        whatsHot(false);
                     }
 
                     filterChatSpecificRightPanelStates();
@@ -969,8 +969,10 @@
         });
     }
 
-    function whatsHot() {
-        push("/");
+    function whatsHot(navigate: boolean = true) {
+        if (navigate) {
+            push("/");
+        }
         tick().then(() => {
             interruptRecommended = false;
             hotGroups = { kind: "loading" };
@@ -1105,7 +1107,7 @@
             on:searchEntered={performSearch}
             on:userAvatarSelected={userAvatarSelected}
             on:chatWith={chatWith}
-            on:whatsHot={whatsHot}
+            on:whatsHot={() => whatsHot(true)}
             on:newGroup={newGroup}
             on:profile={showProfile}
             on:logout={logout}
@@ -1139,7 +1141,7 @@
             on:joinGroup={joinGroup}
             on:cancelPreview={cancelPreview}
             on:cancelRecommendations={cancelRecommendations}
-            on:recommend={whatsHot}
+            on:recommend={() => whatsHot(false)}
             on:dismissRecommendation={dismissRecommendation}
             on:upgrade={upgrade}
             on:showPinned={showPinned}


### PR DESCRIPTION
When we first load we automatically show what's hot. This included an unnecessary `push("/")`. This caused a race condition resulting in the closing of the faq modal immediately after it had opened. 

fixes #2500 