### PR TITLE
End overdue polls in `post_upgrade`

### DIFF
--- a/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
@@ -7,6 +7,7 @@ use ic_cdk_macros::post_upgrade;
 use stable_memory::deserialize_from_stable_memory;
 use tracing::info;
 use utils::env::canister::CanisterEnv;
+use utils::env::Environment;
 
 #[post_upgrade]
 #[trace]
@@ -15,8 +16,10 @@ fn post_upgrade(args: Args) {
 
     let env = Box::new(CanisterEnv::new());
 
-    let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+    let (mut data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
         deserialize_from_stable_memory(UPGRADE_BUFFER_SIZE).unwrap();
+
+    data.events.end_overdue_polls(env.now());
 
     init_logger(data.test_mode);
     init_state(env, data, args.wasm_version);

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -827,6 +827,22 @@ impl ChatEvents {
         }
     }
 
+    pub fn end_overdue_polls(&mut self, now: TimestampMillis) {
+        let mut overdue_polls = Vec::new();
+        for message in self.events.iter().filter_map(|e| e.event.as_message()) {
+            if let MessageContentInternal::Poll(p) = &message.content {
+                if let Some(end_date) = p.config.end_date {
+                    if end_date < now {
+                        overdue_polls.push(message.message_index);
+                    }
+                }
+            }
+        }
+        for message_index in overdue_polls {
+            self.end_poll(message_index, now);
+        }
+    }
+
     pub fn get(&self, event_index: EventIndex) -> Option<&EventWrapper<ChatEventInternal>> {
         self.events.get(event_index)
     }


### PR DESCRIPTION
Our 'callback' canister ran out of cycles temporarily so some polls weren't marked as ended.

Soon the callback canister will be redundant. For now I've just topped it up with 10T cycles.