### PR TITLE
Speed up build by using `dev-dependencies`

### DIFF
--- a/backend/integration_tests/Cargo.toml
+++ b/backend/integration_tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 callback_canister = { path = "../canisters/callback/api" }
 candid = { workspace = true }
 group_canister = { path = "../canisters/group/api" }


### PR DESCRIPTION
This avoids building all of the integration test dependencies unnecessarily.