### PR TITLE
Fix canister path for testnets

### DIFF
--- a/frontend/app/rollup.config.js
+++ b/frontend/app/rollup.config.js
@@ -30,7 +30,9 @@ const dfxNetwork = process.env.DFX_NETWORK;
 console.log("DFX_NETWORK: ", dfxNetwork);
 
 if (dfxNetwork) {
-    const canisterPath = dfxNetwork.startsWith("ic")
+    const dfxJsonPath = path.join(__dirname, "../..", "dfx.json");
+    const dfxJson = JSON.parse(fs.readFileSync(dfxJsonPath));
+    const canisterPath = dfxJson["networks"][dfxNetwork]["type"] === "persistent"
         ? path.join(__dirname, "../..", "canister_ids.json")
         : path.join(__dirname, "../..", ".dfx", dfxNetwork, "canister_ids.json");
 


### PR DESCRIPTION
If network type is "persistent", get from `canister_ids.json`, else get from `.dfx`.