### PR TITLE
Move some more stuff into the openchat lib

### DIFF
--- a/frontend/app/src/components/home/ChatEvent.svelte
+++ b/frontend/app/src/components/home/ChatEvent.svelte
@@ -69,16 +69,6 @@
     function editEvent() {
         dispatch("editEvent", event as EventWrapper<Message>);
     }
-
-    function initiateThread() {
-        if (event.event.kind === "message") {
-            if (event.event.thread !== undefined) {
-                push(`/${chatId}/${event.event.messageIndex}`);
-            } else {
-                dispatch("initiateThread", { rootEvent: event });
-            }
-        }
-    }
 </script>
 
 {#if event.event.kind === "message"}
@@ -114,7 +104,6 @@
         on:goToMessageIndex
         on:replyPrivatelyTo
         on:replyTo
-        on:initiateThread={initiateThread}
         on:selectReaction
         on:deleteMessage
         on:blockUser

--- a/frontend/app/src/components/home/ChatList.svelte
+++ b/frontend/app/src/components/home/ChatList.svelte
@@ -11,7 +11,6 @@
         GroupSearchResponse,
         MessageMatch,
         SearchAllMessagesResponse,
-        CreatedUser,
         UserSummary,
         DataContent,
         OpenChat,
@@ -180,7 +179,6 @@
                     <ChatSummary
                         index={i}
                         {chatSummary}
-                        {userId}
                         selected={$selectedChatId === chatSummary.chatId}
                         visible={searchTerm !== "" || !chatSummary.archived}
                         on:chatSelected={chatSelected}

--- a/frontend/app/src/components/home/ChatList.svelte
+++ b/frontend/app/src/components/home/ChatList.svelte
@@ -25,6 +25,7 @@
     import { menuCloser } from "../../actions/closeMenu";
 
     const client = getContext<OpenChat>("client");
+    const createdUser = client.user;
 
     export let groupSearchResults: Promise<GroupSearchResponse> | undefined = undefined;
     export let userSearchResults: Promise<UserSummary[]> | undefined = undefined;
@@ -32,7 +33,6 @@
     export let searchTerm: string = "";
     export let searching: boolean = false;
     export let searchResultsAvailable: boolean = false;
-    export let createdUser: CreatedUser;
 
     const dispatch = createEventDispatcher();
 

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -181,7 +181,7 @@
         if (msg.thread !== undefined) {
             push(`/${chatId}/${msg.messageIndex}`);
         } else {
-            client.openThread(chatId, msg.messageId, true);
+            client.openThread(msg.messageId, msg.messageIndex, true);
         }
     }
 

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -52,6 +52,7 @@
     import ThreadSummary from "./ThreadSummary.svelte";
     import { pathParams } from "../../stores/routing";
     import { canShareMessage } from "../../utils/share";
+    import { push } from "svelte-spa-router";
 
     const client = getContext<OpenChat>("client");
     const dispatch = createEventDispatcher();
@@ -177,7 +178,11 @@
 
     // this is called if we are starting a new thread so we pass undefined as the threadSummary param
     function initiateThread() {
-        dispatch("initiateThread");
+        if (msg.thread !== undefined) {
+            push(`/${chatId}/${msg.messageIndex}`);
+        } else {
+            client.openThread(chatId, msg.messageId, true);
+        }
     }
 
     function forward() {

--- a/frontend/app/src/components/home/ChatSummary.svelte
+++ b/frontend/app/src/components/home/ChatSummary.svelte
@@ -17,7 +17,7 @@
     import Markdown from "./Markdown.svelte";
     import { pop } from "../../utils/transition";
     import Typing from "../Typing.svelte";
-    import { createEventDispatcher, getContext, onDestroy, onMount } from "svelte";
+    import { createEventDispatcher, getContext, onMount } from "svelte";
     import { now } from "../../stores/time";
     import { iconSize } from "../../stores/iconSize";
     import { mobileWidth } from "../../stores/screenDimensions";
@@ -27,10 +27,10 @@
     import { notificationsSupported } from "../../utils/notifications";
 
     const client = getContext<OpenChat>("client");
+    const userId = client.user.userId;
 
     export let index: number;
     export let chatSummary: ChatSummary;
-    export let userId: string;
     export let selected: boolean;
     export let visible: boolean;
 

--- a/frontend/app/src/components/home/CurrentChat.svelte
+++ b/frontend/app/src/components/home/CurrentChat.svelte
@@ -3,7 +3,7 @@
     import CurrentChatMessages from "./CurrentChatMessages.svelte";
     import Footer from "./Footer.svelte";
     import { closeNotificationsForChat } from "../../utils/notifications";
-    import { getContext, onDestroy, onMount, tick } from "svelte";
+    import { getContext, onMount, tick } from "svelte";
     import type {
         ChatEvent,
         ChatSummary,
@@ -163,7 +163,9 @@
             events,
             textContent,
             mentioned,
-            fileToAttach
+            fileToAttach,
+            $currentChatReplyingTo,
+            undefined
         );
     }
 

--- a/frontend/app/src/components/home/CurrentChat.svelte
+++ b/frontend/app/src/components/home/CurrentChat.svelte
@@ -239,12 +239,9 @@
         bind:this={currentChatMessages}
         on:replyPrivatelyTo
         on:replyTo={replyTo}
-        on:openThread
         on:chatWith
         on:upgrade
         on:forward
-        on:closeThread
-        on:initiateThread
         {chat}
         {serverChat}
         {events}

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -27,7 +27,6 @@
         FilteredProposals,
         WebRtcMessage,
         MessageReadState,
-        RemoteUserSentMessage,
         LoadedNewMessages,
         ChatUpdated,
         LoadedMessageWindow,
@@ -74,8 +73,6 @@
     $: currentChatEditingEvent = client.currentChatEditingEvent;
     $: currentChatPinnedMessages = client.currentChatPinnedMessages;
     $: messagesRead = client.messagesRead;
-    $: typing = client.typing;
-    $: localMessageUpdates = client.localMessageUpdates;
     $: unconfirmedReadByThem = client.unconfirmedReadByThem;
     $: unconfirmed = client.unconfirmed;
     $: userGroupKeys = client.userGroupKeys;
@@ -259,7 +256,7 @@
             const msgEvent = findMessageEvent(index);
             if (msgEvent) {
                 if (msgEvent.event.thread !== undefined && $pathParams.open) {
-                    client.openThread(chat.chatId, msgEvent.event.messageId, false);
+                    client.openThread(msgEvent.event.messageId, msgEvent.event.messageIndex, false);
                 } else {
                     client.closeThread();
                 }
@@ -384,16 +381,6 @@
                     client.trackEvent("reacted_to_message");
                 }
             });
-
-        client.sendRtcMessage([...$currentChatUserIds], {
-            kind: "remote_user_toggled_reaction",
-            chatType: chat.kind,
-            chatId: chat.chatId,
-            messageId: message.messageId,
-            reaction,
-            userId: user.userId,
-            added: kind === "add",
-        });
     }
 
     function onSelectReactionEv(ev: CustomEvent<{ message: Message; reaction: string }>) {
@@ -703,55 +690,6 @@
             onMessageWindowLoaded(jumpingTo);
         } else {
             tick().then(() => scrollBottom("smooth"));
-        }
-    }
-
-    function remoteUserSentMessage(message: RemoteUserSentMessage): void {
-        const existing = client.findMessageById(message.messageEvent.event.messageId, events);
-        if (existing !== undefined) {
-            return;
-        }
-
-        // We should overwrite the event index and message index to ensure these new messages always get placed at the
-        // end rather than before any unconfirmed messages we have sent. Also, for direct chats the indexes can mismatch
-        // due to either user being blocked temporarily, so by overwriting the indexes we avoid issues caused by this.
-        const [eventIndex, messageIndex] = client.nextEventAndMessageIndexes();
-        unconfirmed.add(chat.chatId, {
-            ...message.messageEvent,
-            index: eventIndex,
-            event: {
-                ...message.messageEvent.event,
-                messageIndex,
-            },
-        });
-    }
-
-    export function handleWebRtcMessage(fromChatId: string, msg: WebRtcMessage): void {
-        switch (msg.kind) {
-            case "remote_user_typing":
-                typing.startTyping(fromChatId, msg.userId, msg.threadRootMessageIndex);
-                break;
-            case "remote_user_stopped_typing":
-                typing.stopTyping(msg.userId);
-                break;
-            case "remote_user_toggled_reaction":
-                client.remoteUserToggledReaction(events, msg);
-                break;
-            case "remote_user_deleted_message":
-                localMessageUpdates.markDeleted(msg.messageId.toString(), msg.userId);
-                break;
-            case "remote_user_removed_message":
-                client.removeMessage(user.userId, chat, msg.messageId, msg.userId);
-                break;
-            case "remote_user_undeleted_message":
-                localMessageUpdates.markUndeleted(msg.messageId.toString());
-                break;
-            case "remote_user_sent_message":
-                remoteUserSentMessage(msg);
-                break;
-            case "remote_user_read_message":
-                unconfirmedReadByThem.add(BigInt(msg.messageId));
-                break;
         }
     }
 </script>

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -263,11 +263,9 @@
             const msgEvent = findMessageEvent(index);
             if (msgEvent) {
                 if (msgEvent.event.thread !== undefined && $pathParams.open) {
-                    dispatch("openThread", {
-                        rootEvent: msgEvent,
-                    });
+                    client.openThread(chat.chatId, msgEvent.event.messageId, false);
                 } else {
-                    dispatch("closeThread");
+                    client.closeThread();
                 }
             }
             if (!preserveFocus) {
@@ -532,16 +530,6 @@
         if (chat.chatId !== currentChatId) {
             currentChatId = chat.chatId;
             initialised = false;
-
-            if ($focusMessageIndex !== undefined) {
-                client.loadEventWindow(serverChat, chat, $focusMessageIndex).then(() => {
-                    client.loadDetails(chat, events);
-                });
-            } else {
-                client.loadPreviousMessages(serverChat, chat).then(() => {
-                    client.loadDetails(chat, events);
-                });
-            }
         }
     }
 
@@ -814,7 +802,6 @@
                         pinned={isPinned($currentChatPinnedMessages, evt)}
                         editing={$currentChatEditingEvent === evt}
                         on:chatWith
-                        on:initiateThread
                         on:replyTo={replyTo}
                         on:replyPrivatelyTo
                         on:deleteMessage={onDeleteMessage}

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -175,11 +175,7 @@
         }
     }
 
-    async function newChatSelected(
-        chatId: string,
-        messageIndex?: number,
-        threadMessageIndex?: number
-    ): Promise<void> {
+    async function newChatSelected(chatId: string, messageIndex?: number): Promise<void> {
         interruptRecommended = true;
 
         let chat = $chatSummariesStore[chatId];
@@ -215,7 +211,7 @@
 
         // if it's a known chat let's select it
         closeNotificationsForChat(chat.chatId);
-        client.setSelectedChat(client.api, chat, messageIndex, threadMessageIndex);
+        client.setSelectedChat(client.api, chat, messageIndex);
         resetRightPanel();
         hotGroups = { kind: "idle" };
     }
@@ -250,20 +246,11 @@
                 if (pathParams.chatId !== undefined) {
                     // if the chat in the url is different from the chat we already have selected
                     if (pathParams.chatId !== $selectedChatId?.toString()) {
-                        newChatSelected(
-                            pathParams.chatId,
-                            pathParams.messageIndex,
-                            pathParams.threadMessageIndex
-                        );
+                        newChatSelected(pathParams.chatId, pathParams.messageIndex);
                     } else {
                         // if the chat in the url is *the same* as the selected chat
                         // *and* if we have a messageIndex specified in the url
                         if (pathParams.messageIndex !== undefined) {
-                            chatStateStore.setProp(
-                                pathParams.chatId,
-                                "focusThreadMessageIndex",
-                                pathParams.threadMessageIndex
-                            );
                             currentChatMessages?.scrollToMessageIndex(
                                 pathParams.messageIndex,
                                 false,

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -211,7 +211,7 @@
 
         // if it's a known chat let's select it
         closeNotificationsForChat(chat.chatId);
-        client.setSelectedChat(client.api, chat, messageIndex);
+        client.setSelectedChat(chat, messageIndex);
         resetRightPanel();
         hotGroups = { kind: "idle" };
     }

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -149,7 +149,6 @@
         ($mobileWidth && $pathParams.chatId === undefined && hotGroups.kind !== "idle");
 
     onMount(() => {
-        client.initWebRtc();
         subscribeToNotifications(client, (n) => client.notificationReceived(n));
         client.addEventListener("openchat_event", clientEvent);
 

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -825,7 +825,6 @@
 <main class:fullscreen={$fullScreen}>
     {#if showLeft}
         <LeftPanel
-            {user}
             {groupSearchResults}
             {userSearchResults}
             {messageSearchResults}

--- a/frontend/app/src/components/home/LeftPanel.svelte
+++ b/frontend/app/src/components/home/LeftPanel.svelte
@@ -14,7 +14,6 @@
     export let searchTerm: string = "";
     export let searching: boolean = false;
     export let searchResultsAvailable: boolean = false;
-    export let user: CreatedUser;
 
     // TODO - this component doesn't do anything now. We could remove it but it might be a useful abstraction
 </script>
@@ -42,7 +41,6 @@
             on:archiveChat
             on:unarchiveChat
             on:toggleMuteNotifications
-            createdUser={user}
             {searchResultsAvailable}
             {searchTerm}
             {searching}

--- a/frontend/app/src/components/home/MiddlePanel.svelte
+++ b/frontend/app/src/components/home/MiddlePanel.svelte
@@ -55,7 +55,6 @@
             serverChat={$selectedServerChatStore}
             events={$eventsStore}
             filteredProposals={$filteredProposalsStore}
-            on:initiateThread
             on:unblockUser
             on:clearSelection
             on:blockUser
@@ -71,9 +70,7 @@
             on:cancelPreview
             on:showPinned
             on:toggleMuteNotifications
-            on:openThread
             on:goToMessageIndex
-            on:closeThread
             on:forward />
     {/if}
 </Panel>

--- a/frontend/app/src/components/home/RightPanel.svelte
+++ b/frontend/app/src/components/home/RightPanel.svelte
@@ -11,7 +11,6 @@
     import type {
         AddMembersResponse,
         ChatEvent,
-        ChatMetrics,
         EventWrapper,
         FullMember,
         GroupChatSummary,
@@ -35,7 +34,6 @@
     const dispatch = createEventDispatcher();
 
     export let rightPanelHistory: RightPanelState[];
-    export let thread: Thread | undefined;
 
     const client = getContext<OpenChat>("client");
     const currentUser = client.user;
@@ -44,6 +42,7 @@
 
     $: selectedChatId = client.selectedChatId;
     $: selectedChatStore = client.selectedChatStore;
+    $: selectedServerChatStore = client.selectedServerChatStore;
     $: currentChatMembers = client.currentChatMembers;
     $: currentChatBlockedUsers = client.currentChatBlockedUsers;
     $: currentChatPinnedMessages = client.currentChatPinnedMessages;
@@ -384,13 +383,13 @@
             on:closeProfile={popHistory} />
     {:else if lastState.kind === "new_group_panel"}
         <NewGroup {currentUser} on:cancelNewGroup={popHistory} on:groupCreated />
-    {:else if threadRootEvent !== undefined && $selectedChatStore !== undefined}
+    {:else if threadRootEvent !== undefined && $selectedChatStore !== undefined && $selectedServerChatStore !== undefined}
         <Thread
-            bind:this={thread}
             on:chatWith
             on:upgrade
             rootEvent={threadRootEvent}
             chat={$selectedChatStore}
+            serverChat={$selectedServerChatStore}
             on:closeThread={closeThread} />
     {:else if lastState.kind === "proposal_filters" && $selectedChatId !== undefined}
         <ProposalGroupFilters on:close={popHistory} />

--- a/frontend/app/src/components/home/RightPanel.svelte
+++ b/frontend/app/src/components/home/RightPanel.svelte
@@ -48,7 +48,6 @@
     $: currentChatBlockedUsers = client.currentChatBlockedUsers;
     $: currentChatPinnedMessages = client.currentChatPinnedMessages;
     $: currentChatRules = client.currentChatRules;
-    $: focusThreadMessageIndex = client.focusThreadMessageIndex;
     $: chatStateStore = client.chatStateStore;
     $: eventsStore = client.eventsStore;
     $: userStore = client.userStore;
@@ -330,7 +329,7 @@
 
     $: threadRootEvent =
         lastState.kind === "message_thread_panel" && $selectedChatId !== undefined
-            ? findMessage($eventsStore, lastState.rootEvent.event.messageId)
+            ? findMessage($eventsStore, lastState.threadRootMessageId)
             : undefined;
 </script>
 

--- a/frontend/app/src/components/home/RightPanel.svelte
+++ b/frontend/app/src/components/home/RightPanel.svelte
@@ -391,7 +391,6 @@
             on:chatWith
             on:upgrade
             rootEvent={threadRootEvent}
-            focusMessageIndex={$focusThreadMessageIndex}
             chat={$selectedChatStore}
             on:closeThread={closeThread} />
     {:else if lastState.kind === "proposal_filters" && $selectedChatId !== undefined}

--- a/frontend/app/src/components/home/ThreadsSection.svelte
+++ b/frontend/app/src/components/home/ThreadsSection.svelte
@@ -19,7 +19,7 @@
 
     onMount(() => {
         return messagesRead.subscribe(() => {
-            numStaleThreads = messagesRead.staleThreadsCount($threadsByChatStore);
+            numStaleThreads = client.staleThreadsCount($threadsByChatStore);
         });
     });
 </script>

--- a/frontend/app/src/components/home/groupdetails/GroupDetails.svelte
+++ b/frontend/app/src/components/home/groupdetails/GroupDetails.svelte
@@ -269,29 +269,16 @@
     }
 
     function doUpdateRules(): Promise<void> {
-        return client.api
-            .updateGroup(
-                updatedGroup.chatId,
-                undefined,
-                undefined,
-                updatedRules,
-                undefined,
-                undefined
-            )
-            .then((resp) => {
-                if (resp === "success") {
-                    dispatch("updateGroupRules", {
-                        chatId: updatedGroup.chatId,
-                        rules: updatedRules,
-                    });
-                } else {
-                    toastStore.showFailureToast("group.rulesUpdateFailed");
-                }
-            })
-            .catch((err) => {
-                rollbar.error("Update group rules failed: ", err);
+        return client.updateGroupRules(updatedGroup.chatId, updatedRules).then((success) => {
+            if (success) {
+                dispatch("updateGroupRules", {
+                    chatId: updatedGroup.chatId,
+                    rules: updatedRules,
+                });
+            } else {
                 toastStore.showFailureToast("group.rulesUpdateFailed");
-            });
+            }
+        });
     }
 
     function updatePermissions() {
@@ -305,23 +292,14 @@
     }
 
     function doUpdatePermissions(): Promise<void> {
-        const optionalPermissions = client.mergeKeepingOnlyChanged(
-            originalGroup.permissions,
-            updatedGroup.permissions
-        );
-        console.log("Changed permissions: ", optionalPermissions);
-
-        return client.api
-            .updateGroup(
+        return client
+            .updateGroupPermissions(
                 updatedGroup.chatId,
-                undefined,
-                undefined,
-                undefined,
-                optionalPermissions,
-                undefined
+                originalGroup.permissions,
+                updatedGroup.permissions
             )
-            .then((resp) => {
-                if (resp === "success") {
+            .then((success) => {
+                if (success) {
                     originalGroup = {
                         ...originalGroup,
                         permissions: updatedGroup.permissions,
@@ -330,10 +308,6 @@
                 } else {
                     toastStore.showFailureToast("group.permissionsUpdateFailed");
                 }
-            })
-            .catch((err) => {
-                rollbar.error("Update permissions failed: ", err);
-                toastStore.showFailureToast("group.permissionsUpdateFailed");
             });
     }
 

--- a/frontend/app/src/components/home/rightPanel.ts
+++ b/frontend/app/src/components/home/rightPanel.ts
@@ -1,4 +1,4 @@
-import type { ChatSummary, EventWrapper, GroupPermissions, Message } from "openchat-client";
+import type { ChatSummary, GroupPermissions } from "openchat-client";
 
 export type RightPanelState =
     | GroupDetailsPanel
@@ -17,6 +17,7 @@ export type NoPanel = {
 
 export type MessageThreadPanel = {
     kind: "message_thread_panel";
+    threadRootMessageIndex: number;
     threadRootMessageId: bigint;
 };
 

--- a/frontend/app/src/components/home/rightPanel.ts
+++ b/frontend/app/src/components/home/rightPanel.ts
@@ -17,7 +17,7 @@ export type NoPanel = {
 
 export type MessageThreadPanel = {
     kind: "message_thread_panel";
-    rootEvent: EventWrapper<Message>;
+    threadRootMessageId: bigint;
 };
 
 export type GroupDetailsPanel = {

--- a/frontend/app/src/components/home/thread/Thread.svelte
+++ b/frontend/app/src/components/home/thread/Thread.svelte
@@ -43,9 +43,9 @@
     const client = getContext<OpenChat>("client");
 
     export let rootEvent: EventWrapper<Message>;
-    export let focusMessageIndex: number | undefined;
     export let chat: ChatSummary;
 
+    let focusMessageIndex: number | undefined = undefined;
     let observer: IntersectionObserver = new IntersectionObserver(() => {});
     let pollBuilder: PollBuilder;
     let giphySelector: GiphySelector;
@@ -569,7 +569,6 @@
 
     function clearFocusIndex() {
         focusMessageIndex = undefined;
-        chatStateStore.setProp(chat.chatId, "focusThreadMessageIndex", undefined);
     }
 
     function goToMessageIndex(index: number) {

--- a/frontend/app/src/stores/routing.ts
+++ b/frontend/app/src/stores/routing.ts
@@ -4,7 +4,6 @@ import { derived, get } from "svelte/store";
 export type RouteParams = {
     chatId?: string;
     messageIndex?: number;
-    threadMessageIndex?: number;
     open: boolean;
 };
 

--- a/frontend/openchat-client/src/domain/chat/chat.ts
+++ b/frontend/openchat-client/src/domain/chat/chat.ts
@@ -787,7 +787,6 @@ export type ChatSpecificState = {
     rules?: GroupRules;
     userIds: Set<string>;
     focusMessageIndex?: number;
-    focusThreadMessageIndex?: number;
     userGroupKeys: Set<string>;
     serverEvents: EventWrapper<ChatEvent>[];
 };

--- a/frontend/openchat-client/src/events.ts
+++ b/frontend/openchat-client/src/events.ts
@@ -41,3 +41,24 @@ export class ChatUpdated extends Event {
         super("openchat_event");
     }
 }
+
+export class ThreadMessagesLoaded extends CustomEvent<boolean> {
+    constructor(ascending: boolean) {
+        super("openchat_event", { detail: ascending });
+    }
+}
+
+export class ThreadSelected extends CustomEvent<{
+    initiating: boolean;
+    threadRootMessageId: bigint;
+}> {
+    constructor(threadRootMessageId: bigint, initiating: boolean) {
+        super("openchat_event", { detail: { threadRootMessageId, initiating } });
+    }
+}
+
+export class ThreadClosed extends Event {
+    constructor() {
+        super("openchat_event");
+    }
+}

--- a/frontend/openchat-client/src/events.ts
+++ b/frontend/openchat-client/src/events.ts
@@ -1,3 +1,5 @@
+import type { EventWrapper, Message } from "./domain";
+
 export class UpgradeRequired extends CustomEvent<"explain" | "icp" | "sms"> {
     constructor(mode: "explain" | "icp" | "sms") {
         super("openchat_event", { detail: mode });
@@ -22,6 +24,12 @@ export class SentMessage extends CustomEvent<number | undefined> {
     }
 }
 
+export class SentThreadMessage extends CustomEvent<EventWrapper<Message>> {
+    constructor(event: EventWrapper<Message>) {
+        super("openchat_event", { detail: event });
+    }
+}
+
 export class LoadedMessageWindow extends CustomEvent<number> {
     constructor(messageIndex: number) {
         super("openchat_event", { detail: messageIndex });
@@ -43,9 +51,12 @@ export class ThreadMessagesLoaded extends CustomEvent<boolean> {
 export class ThreadSelected extends CustomEvent<{
     initiating: boolean;
     threadRootMessageId: bigint;
+    threadRootMessageIndex: number;
 }> {
-    constructor(threadRootMessageId: bigint, initiating: boolean) {
-        super("openchat_event", { detail: { threadRootMessageId, initiating } });
+    constructor(threadRootMessageId: bigint, threadRootMessageIndex: number, initiating: boolean) {
+        super("openchat_event", {
+            detail: { threadRootMessageId, initiating, threadRootMessageIndex },
+        });
     }
 }
 

--- a/frontend/openchat-client/src/liveState.ts
+++ b/frontend/openchat-client/src/liveState.ts
@@ -22,6 +22,8 @@ import {
     threadEvents,
     selectedThreadKey,
     threadsFollowedByMeStore,
+    currentChatUserIds,
+    selectedThreadRootMessageIndex,
 } from "./stores/chat";
 import { remainingStorage } from "./stores/storage";
 import { userCreatedStore } from "./stores/userCreated";
@@ -50,6 +52,8 @@ export class LiveState {
     threadEvents!: EventWrapper<ChatEvent>[];
     selectedThreadKey: string | undefined;
     threadsFollowedByMe!: Record<string, Set<number>>;
+    currentChatUserIds!: Set<string>;
+    selectedThreadRootMessageIndex: number | undefined;
 
     constructor() {
         remainingStorage.subscribe((data) => (this.remainingStorage = data));
@@ -70,5 +74,9 @@ export class LiveState {
         threadEvents.subscribe((data) => (this.threadEvents = data));
         selectedThreadKey.subscribe((data) => (this.selectedThreadKey = data));
         threadsFollowedByMeStore.subscribe((data) => (this.threadsFollowedByMe = data));
+        currentChatUserIds.subscribe((data) => (this.currentChatUserIds = data));
+        selectedThreadRootMessageIndex.subscribe(
+            (data) => (this.selectedThreadRootMessageIndex = data)
+        );
     }
 }

--- a/frontend/openchat-client/src/liveState.ts
+++ b/frontend/openchat-client/src/liveState.ts
@@ -4,6 +4,7 @@ import type {
     ChatSummary,
     EnhancedReplyContext,
     EventWrapper,
+    ThreadSyncDetails,
     UserLookup,
 } from "./domain";
 import { selectedAuthProviderStore } from "./stores/authProviders";
@@ -16,6 +17,7 @@ import {
     selectedServerChatStore,
     currentChatReplyingTo,
     chatSummariesListStore,
+    threadsByChatStore,
 } from "./stores/chat";
 import { remainingStorage } from "./stores/storage";
 import { userCreatedStore } from "./stores/userCreated";
@@ -38,6 +40,7 @@ export class LiveState {
     selectedChatId: string | undefined;
     pinnedChats!: string[];
     chatSummariesList!: ChatSummary[];
+    threadsByChat!: Record<string, ThreadSyncDetails[]>;
 
     constructor() {
         remainingStorage.subscribe((data) => (this.remainingStorage = data));
@@ -53,5 +56,6 @@ export class LiveState {
         currentChatReplyingTo.subscribe((data) => (this.currentChatReplyingTo = data));
         pinnedChatsStore.subscribe((data) => (this.pinnedChats = data));
         chatSummariesListStore.subscribe((data) => (this.chatSummariesList = data));
+        threadsByChatStore.subscribe((data) => (this.threadsByChat = data));
     }
 }

--- a/frontend/openchat-client/src/liveState.ts
+++ b/frontend/openchat-client/src/liveState.ts
@@ -18,6 +18,10 @@ import {
     currentChatReplyingTo,
     chatSummariesListStore,
     threadsByChatStore,
+    focusMessageIndex,
+    threadEvents,
+    selectedThreadKey,
+    threadsFollowedByMeStore,
 } from "./stores/chat";
 import { remainingStorage } from "./stores/storage";
 import { userCreatedStore } from "./stores/userCreated";
@@ -30,6 +34,7 @@ import { pinnedChatsStore } from "./stores/pinnedChats";
  */
 export class LiveState {
     selectedChat: ChatSummary | undefined;
+    selectedServerChat: ChatSummary | undefined;
     events!: EventWrapper<ChatEvent>[];
     selectedAuthProvider!: AuthProvider;
     userCreated!: boolean;
@@ -41,6 +46,10 @@ export class LiveState {
     pinnedChats!: string[];
     chatSummariesList!: ChatSummary[];
     threadsByChat!: Record<string, ThreadSyncDetails[]>;
+    focusMessageIndex: number | undefined;
+    threadEvents!: EventWrapper<ChatEvent>[];
+    selectedThreadKey: string | undefined;
+    threadsFollowedByMe!: Record<string, Set<number>>;
 
     constructor() {
         remainingStorage.subscribe((data) => (this.remainingStorage = data));
@@ -52,10 +61,14 @@ export class LiveState {
         selectedChatId.subscribe((data) => (this.selectedChatId = data));
         eventsStore.subscribe((data) => (this.events = data));
         selectedChatStore.subscribe((data) => (this.selectedChat = data));
-        selectedServerChatStore.subscribe((data) => (this.selectedChat = data));
+        selectedServerChatStore.subscribe((data) => (this.selectedServerChat = data));
         currentChatReplyingTo.subscribe((data) => (this.currentChatReplyingTo = data));
         pinnedChatsStore.subscribe((data) => (this.pinnedChats = data));
         chatSummariesListStore.subscribe((data) => (this.chatSummariesList = data));
         threadsByChatStore.subscribe((data) => (this.threadsByChat = data));
+        focusMessageIndex.subscribe((data) => (this.focusMessageIndex = data));
+        threadEvents.subscribe((data) => (this.threadEvents = data));
+        selectedThreadKey.subscribe((data) => (this.selectedThreadKey = data));
+        threadsFollowedByMeStore.subscribe((data) => (this.threadsFollowedByMe = data));
     }
 }

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -12,6 +12,8 @@ import type {
     Notification,
     GroupChatSummary,
     MemberRole,
+    GroupRules,
+    GroupPermissions,
 } from "./domain";
 import { AuthProvider } from "./domain";
 import {
@@ -791,6 +793,35 @@ export class OpenChat extends EventTarget {
             .catch((err) => {
                 rollbar.error("Unable to join group", err);
                 return "failure";
+            });
+    }
+
+    updateGroupRules(chatId: string, rules: GroupRules | undefined): Promise<boolean> {
+        return this.api
+            .updateGroup(chatId, undefined, undefined, rules, undefined, undefined)
+            .then((resp) => resp === "success")
+            .catch((err) => {
+                rollbar.error("Update group rules failed: ", err);
+                return false;
+            });
+    }
+
+    updateGroupPermissions(
+        chatId: string,
+        originalPermissions: GroupPermissions,
+        updatedPermissions: GroupPermissions
+    ): Promise<boolean> {
+        const optionalPermissions = this.mergeKeepingOnlyChanged(
+            originalPermissions,
+            updatedPermissions
+        );
+
+        return this.api
+            .updateGroup(chatId, undefined, undefined, undefined, optionalPermissions, undefined)
+            .then((resp) => resp === "success")
+            .catch((err) => {
+                rollbar.error("Update permissions failed: ", err);
+                return false;
             });
     }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1389,7 +1389,7 @@ export class OpenChat extends EventTarget {
             // this is a webrtc message relating to the selected thread
             this.handleWebRtcMessageInternal(
                 fromChatId,
-                msg,
+                parsedMsg,
                 selectedChat,
                 threadEvents,
                 parsedMsg.threadRootMessageIndex
@@ -1397,7 +1397,13 @@ export class OpenChat extends EventTarget {
         } else {
             if (selectedChat !== undefined && fromChatId === selectedChat.chatId) {
                 // this is a webrtc message relating to the selected chat
-                this.handleWebRtcMessageInternal(fromChatId, msg, selectedChat, events, undefined);
+                this.handleWebRtcMessageInternal(
+                    fromChatId,
+                    parsedMsg,
+                    selectedChat,
+                    events,
+                    undefined
+                );
             } else {
                 if (parsedMsg.kind === "remote_user_sent_message") {
                     unconfirmed.add(fromChatId, parsedMsg.messageEvent);
@@ -1439,7 +1445,6 @@ export class OpenChat extends EventTarget {
                 localMessageUpdates.markUndeleted(msg.messageId.toString());
                 break;
             case "remote_user_sent_message":
-                // FIXME - one more thing to sort out
                 this.remoteUserSentMessage(fromChatId, msg, events, threadRootMessageIndex);
                 break;
             case "remote_user_read_message":

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -950,7 +950,9 @@ export class OpenChat extends EventTarget {
     filterWebRtcMessage = filterWebRtcMessage;
     parseWebRtcMessage = parseWebRtcMessage;
     createDirectChat = createDirectChat;
-    setSelectedChat = setSelectedChat;
+    setSelectedChat(chat: ChatSummary, messageIndex?: number): void {
+        setSelectedChat(this.api, chat, messageIndex);
+    }
     clearSelectedChat = clearSelectedChat;
     removeChat = removeChat;
     canSendMessages = canSendMessages;

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -451,6 +451,7 @@ export class OpenChat extends EventTarget {
             initNotificationStores();
             this.api.getUserStorageLimits();
             this.identityState.set("logged_in");
+            this.initWebRtc();
 
             // FIXME - not sure what to do about this
             // if (isCanisterUrl) {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -137,7 +137,6 @@ import {
     currentUserStore,
     eventsStore,
     focusMessageIndex,
-    focusThreadMessageIndex,
     isProposalGroup,
     nextEventAndMessageIndexes,
     numberOfThreadsStore,
@@ -1251,7 +1250,6 @@ export class OpenChat extends EventTarget {
     selectedChatStore = selectedChatStore;
     currentChatPinnedMessages = currentChatPinnedMessages;
     currentChatRules = currentChatRules;
-    focusThreadMessageIndex = focusThreadMessageIndex;
     proposalTopicsStore = proposalTopicsStore;
     filteredProposalsStore = filteredProposalsStore;
     cryptoBalance = cryptoBalance;

--- a/frontend/openchat-client/src/stores/chat.ts
+++ b/frontend/openchat-client/src/stores/chat.ts
@@ -264,11 +264,6 @@ export const focusMessageIndex = createDerivedPropStore<ChatSpecificState, "focu
     () => undefined
 );
 
-export const focusThreadMessageIndex = createDerivedPropStore<
-    ChatSpecificState,
-    "focusThreadMessageIndex"
->(chatStateStore, "focusThreadMessageIndex", () => undefined);
-
 export const userGroupKeys = createDerivedPropStore<ChatSpecificState, "userGroupKeys">(
     chatStateStore,
     "userGroupKeys",
@@ -313,8 +308,7 @@ export const currentChatPinnedMessages = createDerivedPropStore<
 export function setSelectedChat(
     api: ServiceContainer,
     chat: ChatSummary,
-    messageIndex?: number,
-    threadMessageIndex?: number // FIXME - this is not being used? Do we need it?
+    messageIndex?: number
 ): void {
     // TODO don't think this should be in here really
     if (
@@ -343,7 +337,6 @@ export function setSelectedChat(
     // initialise a bunch of stores
     chatStateStore.clear(chat.chatId);
     chatStateStore.setProp(chat.chatId, "focusMessageIndex", messageIndex);
-    chatStateStore.setProp(chat.chatId, "focusThreadMessageIndex", threadMessageIndex);
     chatStateStore.setProp(
         chat.chatId,
         "userIds",

--- a/frontend/openchat-client/src/stores/chat.ts
+++ b/frontend/openchat-client/src/stores/chat.ts
@@ -246,6 +246,20 @@ export const chatStateStore = createChatSpecificObjectStore<ChatSpecificState>((
     serverEvents: [],
 }));
 
+export const selectedThreadKey = writable<string | undefined>(undefined);
+export const threadServerEventsStore: Writable<EventWrapper<ChatEvent>[]> = immutableStore([]);
+export const threadEvents = derived(
+    [threadServerEventsStore, unconfirmed, localMessageUpdates, selectedThreadKey],
+    ([serverEvents, unconf, localUpdates, threadKey]) => {
+        if (threadKey === undefined) return [];
+        return mergeEventsAndLocalUpdates(
+            serverEvents,
+            unconf[threadKey]?.messages ?? [],
+            localUpdates
+        );
+    }
+);
+
 const serverEventsStore = createDerivedPropStore<ChatSpecificState, "serverEvents">(
     chatStateStore,
     "serverEvents",

--- a/frontend/openchat-client/src/utils/rtc.ts
+++ b/frontend/openchat-client/src/utils/rtc.ts
@@ -4,7 +4,7 @@ import { get } from "svelte/store";
 import type { WebRtcMessage } from "../domain/webrtc/webrtc";
 import { blockedUsers } from "../stores/blockedUsers";
 
-export function delegateToChatComponent(msg: WebRtcMessage): boolean {
+export function messageIsForSelectedChat(msg: WebRtcMessage): boolean {
     const chat = findChatByChatType(msg);
     if (chat === undefined) return false;
     const selectedChat = get(selectedChatStore);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "open-chat",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Make current chat and thread use the same library functions as much as possible. 

Move web rtc handling entirely within the library so that the website code doesn't need to know anything about it. 

A couple of other small simplifications (of which there are many more). 