### PR TITLE
Fix default receiver on ICP transfers

### DIFF
--- a/frontend/app/src/components/home/CryptoTransferBuilder.svelte
+++ b/frontend/app/src/components/home/CryptoTransferBuilder.svelte
@@ -37,11 +37,11 @@
     export let draftAmountE8s: bigint;
     export let token: Cryptocurrency;
     export let chat: ChatSummary;
+    export let defaultReceiver: string | undefined;
 
     $: currentChatBlockedUsers = client.currentChatBlockedUsers;
     $: currentChatMembers = client.currentChatMembers;
     $: lastCryptoSent = client.lastCryptoSent;
-    $: currentChatReplyingTo = client.currentChatReplyingTo;
     $: cryptoBalance = client.cryptoBalance;
     $: userStore = client.userStore;
     let refreshing = false;
@@ -68,14 +68,11 @@
     $: zero = $cryptoBalance[token] <= transferFees && !tokenChanging;
 
     onMount(() => {
-        // default the receiver to the reply sender if we are replying to a specific message
-        if ($currentChatReplyingTo !== undefined) {
-            receiver = $userStore[$currentChatReplyingTo.senderId];
-        }
-
         // default the receiver to the other user in a direct chat
         if (chat.kind === "direct_chat") {
             receiver = $userStore[chat.them];
+        } else {
+            receiver = $userStore[defaultReceiver];
         }
     });
 

--- a/frontend/app/src/components/home/CryptoTransferBuilder.svelte
+++ b/frontend/app/src/components/home/CryptoTransferBuilder.svelte
@@ -71,7 +71,7 @@
         // default the receiver to the other user in a direct chat
         if (chat.kind === "direct_chat") {
             receiver = $userStore[chat.them];
-        } else {
+        } else if (defaultReceiver !== undefined) {
             receiver = $userStore[defaultReceiver];
         }
     });

--- a/frontend/app/src/components/home/CurrentChat.svelte
+++ b/frontend/app/src/components/home/CurrentChat.svelte
@@ -191,6 +191,10 @@
     function isBlocked(chatSummary: ChatSummary, blockedUsers: Set<string>): boolean {
         return chatSummary.kind === "direct_chat" && blockedUsers.has(chatSummary.them);
     }
+
+    function defaultCryptoTransferReceiver(): string | undefined {
+        return $currentChatReplyingTo?.sender?.userId;
+    }
 </script>
 
 <svelte:window on:focus={onWindowFocus} />
@@ -205,6 +209,7 @@
         {chat}
         token={creatingCryptoTransfer.token}
         draftAmountE8s={creatingCryptoTransfer.amount}
+        defaultReceiver={defaultCryptoTransferReceiver()}
         on:sendTransfer={sendMessageWithContent}
         on:close={() => (creatingCryptoTransfer = undefined)} />
 {/if}

--- a/frontend/app/src/components/home/thread/Thread.svelte
+++ b/frontend/app/src/components/home/thread/Thread.svelte
@@ -405,6 +405,10 @@
     function copyMessageUrl(ev: CustomEvent<Message>) {
         shareFunctions.copyMessageUrl(chat.chatId, ev.detail.messageIndex, threadRootMessageIndex);
     }
+
+    function defaultCryptoTransferReceiver(): string | undefined {
+        return $replyingTo?.sender?.userId;
+    }
 </script>
 
 <PollBuilder
@@ -422,6 +426,7 @@
         {chat}
         token={creatingCryptoTransfer.token}
         draftAmountE8s={creatingCryptoTransfer.amount}
+        defaultReceiver={defaultCryptoTransferReceiver()}
         on:sendTransfer={sendMessageWithContent}
         on:close={() => (creatingCryptoTransfer = undefined)} />
 {/if}


### PR DESCRIPTION
Before this PR, the default receiver was always based on who you were replying to in the main chat.

This PR ensures that if sending ICP within a thread, the receiver is defaulted to the user (if any) you are replying to in that thread.