### PR TITLE
fix error handling

### DIFF
--- a/frontend/openchat-agent/src/worker.ts
+++ b/frontend/openchat-agent/src/worker.ts
@@ -69,13 +69,13 @@ function handleAgentEvent(ev: Event): void {
 
 type Uncorrelated = Omit<WorkerResponse, "correlationId" | "kind">;
 
-const sendError = (correlationId: string) => (_: unknown) => {
+const sendError = (correlationId: string) => {
     return (error: unknown) => {
         console.debug("WORKER: sending error: ", error);
         postMessage({
             kind: "worker_error",
             correlationId,
-            error,
+            error: JSON.stringify(error),
         });
     };
 };

--- a/frontend/openchat-client/src/agentWorker.ts
+++ b/frontend/openchat-client/src/agentWorker.ts
@@ -208,7 +208,7 @@ export class OpenChatAgentWorker extends EventTarget {
     private resolveError(data: WorkerError): void {
         const promise = this._pending.get(data.correlationId);
         if (promise !== undefined) {
-            promise.reject(data.error);
+            promise.reject(JSON.parse(data.error));
             window.clearTimeout(promise.timeout);
             this._pending.delete(data.correlationId);
         } else {


### PR DESCRIPTION
Seems like the error handling was _still_ not right. The actual handler function had the wrong signature and also (again) structuredClone seemed to be dropping some of the custom properties of the error so I have changed it to use JSON serialisation in the error case. 

It now logs us out correctly if we get that 403 error on start-up. 