### PR TITLE
remove image caption on zoom

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+  "svelte.plugin.svelte.compilerWarnings": {
+    "a11y-aria-attributes": "ignore",
+    "a11y-click-events-have-key-events": "ignore",
+    "a11y-incorrect-aria-attribute-type": "ignore",
+    "a11y-unknown-aria-attribute": "ignore",
+    "a11y-hidden": "ignore",
+    "a11y-misplaced-role": "ignore",
+    "a11y-unknown-role": "ignore",
+    "a11y-no-abstract-role": "ignore",
+    "a11y-no-redundant-roles": "ignore",
+    "a11y-role-has-required-aria-props": "ignore",
+    "a11y-accesskey": "ignore",
+    "a11y-autofocus": "ignore",
+    "a11y-misplaced-scope": "ignore",
+    "a11y-positive-tabindex": "ignore",
+    "a11y-invalid-attribute": "ignore",
+    "a11y-missing-attribute": "ignore",
+    "a11y-img-redundant-alt": "ignore",
+    "a11y-label-has-associated-control": "ignore",
+    "a11y-media-has-caption": "ignore",
+    "a11y-distracting-elements": "ignore",
+    "a11y-structure": "ignore",
+    "a11y-mouse-events-have-key-events": "ignore",
+    "a11y-missing-content": "ignore"
+  }
+}

--- a/frontend/app/rollup.config.js
+++ b/frontend/app/rollup.config.js
@@ -167,6 +167,10 @@ export default {
                 dev: !production,
                 // immutable: true, // this could be a great optimisation, but we need to plan for it a bit
             },
+            onwarn: (warning, handler) => {
+                if (warning.code.startsWith("a11y-")) return;
+                handler(warning);
+            },
         }),
 
         postcss({ extract: true }),

--- a/frontend/app/src/components/home/ImageContent.svelte
+++ b/frontend/app/src/components/home/ImageContent.svelte
@@ -125,11 +125,6 @@
                 <div class="expand" class:rtl={$rtlStore} class:zoomed={zoom} on:click={toggleZoom}>
                     <ArrowCollapse size={"1em"} color={"#fff"} />
                 </div>
-                {#if withCaption}
-                    <div class="caption">
-                        {content.caption}
-                    </div>
-                {/if}
             </span>
         </ModalContent>
     </Overlay>

--- a/frontend/app/svelte.config.js
+++ b/frontend/app/svelte.config.js
@@ -16,6 +16,10 @@ const preprocessOptions = {
         // prependData: `@import 'v2/frontend/src/styles/mixins.scss';`,
         prependData: `@use 'sass:math'; @import '${mixins}';`,
     },
+    onwarn: (warning, handler) => {
+        if (warning.code.startsWith("a11y-")) return;
+        handler(warning);
+    },
 };
 module.exports = {
     preprocess: sveltePreprocess(preprocessOptions),


### PR DESCRIPTION
couple of people have complained about this and it seems easier (and fine) to just remove the caption when zoomed. 

Also getting rid of all those annoying a11y warnings that have come in with a new version of something or other. 