### PR TITLE
remove dependency on openchat-shared

### DIFF
--- a/frontend/app/src/components/home/RepliesTo.svelte
+++ b/frontend/app/src/components/home/RepliesTo.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
     import type { RehydratedReplyContext, OpenChat } from "openchat-client";
+    import { messageIsVisible } from "openchat-client";
     import { rtlStore } from "../../stores/rtl";
     import Link from "../Link.svelte";
     import { _ } from "svelte-i18n";
@@ -9,7 +10,6 @@
     import { createEventDispatcher, getContext } from "svelte";
     const dispatch = createEventDispatcher();
     import { push } from "svelte-spa-router";
-    import { messageIsVisible } from "openchat-shared";
 
     const client = getContext<OpenChat>("client");
     const currentUser = client.user;
@@ -27,11 +27,12 @@
     $: me = repliesTo.senderId === currentUser.userId;
     $: isTextContent = repliesTo.content?.kind === "text_content";
     $: replyIsVisible = messageIsVisible(
-        $hideDeletedStore, 
-        repliesTo.content, 
-        repliesTo.senderId, 
-        repliesTo.threadRoot, 
-        currentUser.userId);
+        $hideDeletedStore,
+        repliesTo.content,
+        repliesTo.senderId,
+        repliesTo.threadRoot,
+        currentUser.userId
+    );
 
     function zoomToMessage() {
         if (!replyIsVisible) {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -277,7 +277,6 @@ import {
     StorageUpdated,
     UsersLoaded,
     type Logger,
-    RehydratedReplyContext
 } from "openchat-shared";
 
 const UPGRADE_POLL_INTERVAL = 1000;
@@ -2527,13 +2526,12 @@ export class OpenChat extends EventTarget {
     }
 
     setUsername(userId: string, username: string): Promise<SetUsernameResponse> {
-        return this.api.setUsername(userId, username)
-            .then((resp) => {
-                if (resp === "success" && this._user !== undefined) {
-                    this._user.username = username;
-                }
-                return resp;
-            });
+        return this.api.setUsername(userId, username).then((resp) => {
+            if (resp === "success" && this._user !== undefined) {
+                this._user.username = username;
+            }
+            return resp;
+        });
     }
 
     setBio(bio: string): Promise<SetBioResponse> {
@@ -2732,7 +2730,11 @@ export class OpenChat extends EventTarget {
             };
             const chatsResponse =
                 this._chatUpdatesSince === undefined
-                    ? await this.api.getInitialState(userLookup, selectedChat?.chatId, this._liveState.hideDeleted)
+                    ? await this.api.getInitialState(
+                          userLookup,
+                          selectedChat?.chatId,
+                          this._liveState.hideDeleted
+                      )
                     : await this.api.getUpdates(
                           currentState,
                           this.updateArgsFromChats(this._chatUpdatesSince, chats),


### PR DESCRIPTION
Missed this - not sure how it built. the `openchat-shared` project is only meant to me shared between the client and the agent. The `app` project has no dependency on the shared project it gets _everything_ it needs from the client project. 