### PR TITLE
prevent scroll to bottom on send 

### DIFF
--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -573,10 +573,8 @@
         return filteredProposals?.isCollapsed(message.messageId, message.content.proposal) ?? false;
     }
 
-    function afterSendMessage(jumpingTo: number | undefined) {
-        if (jumpingTo !== undefined && jumpingTo !== null) {
-            onMessageWindowLoaded(jumpingTo);
-        } else {
+    function afterSendMessage(upToDate: boolean) {
+        if (upToDate) {
             tick().then(() => scrollBottom("smooth"));
         }
     }

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -574,7 +574,7 @@
     }
 
     function afterSendMessage(upToDate: boolean) {
-        if (upToDate) {
+        if (upToDate && calculateFromBottom() < FROM_BOTTOM_THRESHOLD) {
             tick().then(() => scrollBottom("smooth"));
         }
     }

--- a/frontend/openchat-client/src/events.ts
+++ b/frontend/openchat-client/src/events.ts
@@ -24,9 +24,9 @@ export class LoadedPreviousMessages extends Event {
     }
 }
 
-export class SentMessage extends CustomEvent<number | undefined> {
-    constructor(jumpTo: number | undefined) {
-        super("openchat_event", { detail: jumpTo });
+export class SentMessage extends CustomEvent<boolean> {
+    constructor(upToDate: boolean) {
+        super("openchat_event", { detail: upToDate });
     }
 }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -47,7 +47,7 @@ import {
     buildTransactionLink,
     buildCryptoTransferText,
     mergeSendMessageResponse,
-    upToDate,
+    isUpToDate,
     serialiseMessageForRtc,
 } from "./utils/chat";
 import {
@@ -117,6 +117,7 @@ import {
     addGroupPreview,
     removeGroupPreview,
     groupPreviewsStore,
+    isContiguous,
 } from "./stores/chat";
 import { cryptoBalance, lastCryptoSent } from "./stores/crypto";
 import { draftThreadMessages } from "./stores/draftThreadMessages";
@@ -1288,7 +1289,7 @@ export class OpenChat extends EventTarget {
         if (!keepCurrentEvents) {
             clearServerEvents(chat.chatId);
             chatStateStore.setProp(chat.chatId, "userGroupKeys", new Set<string>());
-        } else if (!this.isContiguous(chat.chatId, resp)) {
+        } else if (!isContiguous(chat.chatId, resp.events)) {
             return;
         }
 
@@ -1304,29 +1305,6 @@ export class OpenChat extends EventTarget {
         addServerEventsToStores(chat.chatId, events, undefined);
 
         makeRtcConnections(this.user.userId, chat, events, this._liveState.userStore);
-    }
-
-    private isContiguous(chatId: string, response: EventsSuccessResult<ChatEvent>): boolean {
-        const confirmedLoaded = confirmedEventIndexesLoaded(chatId);
-
-        if (confirmedLoaded.length === 0 || response.events.length === 0) return true;
-
-        const firstIndex = response.events[0].index;
-        const lastIndex = response.events[response.events.length - 1].index;
-        const contiguousCheck = new DRange(firstIndex - 1, lastIndex + 1);
-
-        const isContiguous = confirmedLoaded.clone().intersect(contiguousCheck).length > 0;
-
-        if (!isContiguous) {
-            console.log(
-                "Events in response are not contiguous with the loaded events",
-                confirmedLoaded,
-                firstIndex,
-                lastIndex
-            );
-        }
-
-        return isContiguous;
     }
 
     private async updateUserStore(chatId: string, userIdsFromEvents: Set<string>): Promise<void> {
@@ -1990,9 +1968,9 @@ export class OpenChat extends EventTarget {
                 this._logger.error("Exception forwarding message", err);
             });
 
-        this.sendMessage(chat, currentEvents, event, undefined).then((jumpTo) => {
-            this.dispatchEvent(new SentMessage(jumpTo));
-            return jumpTo;
+        this.sendMessage(chat, currentEvents, event, undefined).then((upToDate) => {
+            this.dispatchEvent(new SentMessage(upToDate));
+            return upToDate;
         });
     }
 
@@ -2014,21 +1992,15 @@ export class OpenChat extends EventTarget {
         currentEvents: EventWrapper<ChatEvent>[],
         messageEvent: EventWrapper<Message>,
         threadRootMessageIndex: number | undefined
-    ): Promise<number | undefined> {
-        let jumpingTo: number | undefined = undefined;
+    ): Promise<boolean> {
+        let upToDate = true;
         const key =
             threadRootMessageIndex === undefined
                 ? clientChat.chatId
                 : `${clientChat.chatId}_${threadRootMessageIndex}`;
 
         if (threadRootMessageIndex === undefined) {
-            if (!upToDate(clientChat, currentEvents)) {
-                jumpingTo = await this.loadEventWindow(
-                    clientChat.chatId,
-                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    clientChat.latestMessage!.event.messageIndex
-                );
-            }
+            upToDate = isUpToDate(clientChat, currentEvents);
         }
 
         unconfirmed.add(key, messageEvent);
@@ -2056,7 +2028,7 @@ export class OpenChat extends EventTarget {
             currentChatDraftMessage.clear(clientChat.chatId);
         }
 
-        return jumpingTo;
+        return upToDate;
     }
 
     sendMessageWithAttachment(
@@ -2153,14 +2125,16 @@ export class OpenChat extends EventTarget {
                     this.dispatchEvent(new SendMessageFailed());
                 });
 
-            this.sendMessage(chat, currentEvents, event, threadRootMessageIndex).then((jumpTo) => {
-                if (threadRootMessageIndex !== undefined) {
-                    this.dispatchEvent(new SentThreadMessage(event));
-                } else {
-                    this.dispatchEvent(new SentMessage(jumpTo));
+            this.sendMessage(chat, currentEvents, event, threadRootMessageIndex).then(
+                (upToDate) => {
+                    if (threadRootMessageIndex !== undefined) {
+                        this.dispatchEvent(new SentThreadMessage(event));
+                    } else {
+                        this.dispatchEvent(new SentMessage(upToDate));
+                    }
+                    return upToDate;
                 }
-                return jumpTo;
-            });
+            );
         }
     }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-case-declarations */
 import type { Identity } from "@dfinity/agent";
-import DRange from "drange";
 import { AuthClient } from "@dfinity/auth-client";
 import { writable } from "svelte/store";
 import { load } from "@fingerprintjs/botd";

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -222,7 +222,6 @@ import {
     missingUserIds,
     type EventsResponse,
     type ChatEvent,
-    type EventsSuccessResult,
     type ThreadSummary,
     type DataContent,
     type SendMessageSuccess,

--- a/frontend/openchat-client/src/stores/chat.ts
+++ b/frontend/openchat-client/src/stores/chat.ts
@@ -488,12 +488,39 @@ export const eventsStore: Readable<EventWrapper<ChatEvent>[]> = derived(
     }
 );
 
+export function isContiguous(chatId: string, events: EventWrapper<ChatEvent>[]): boolean {
+    const confirmedLoaded = confirmedEventIndexesLoaded(chatId);
+
+    if (confirmedLoaded.length === 0 || events.length === 0) return true;
+
+    const firstIndex = events[0].index;
+    const lastIndex = events[events.length - 1].index;
+    const contiguousCheck = new DRange(firstIndex - 1, lastIndex + 1);
+
+    const isContiguous = confirmedLoaded.clone().intersect(contiguousCheck).length > 0;
+
+    if (!isContiguous) {
+        console.log(
+            "Events in response are not contiguous with the loaded events",
+            confirmedLoaded,
+            firstIndex,
+            lastIndex
+        );
+    }
+
+    return isContiguous;
+}
+
 export function addServerEventsToStores(
     chatId: string,
     newEvents: EventWrapper<ChatEvent>[],
     threadRootMessageIndex: number | undefined
 ): void {
     if (newEvents.length === 0) {
+        return;
+    }
+
+    if (!isContiguous(chatId, newEvents)) {
         return;
     }
 

--- a/frontend/openchat-client/src/utils/chat.ts
+++ b/frontend/openchat-client/src/utils/chat.ts
@@ -63,7 +63,7 @@ export function newMessageId(): bigint {
     return BigInt(parseInt(uuidv1().replace(/-/g, ""), 16));
 }
 
-export function upToDate(chat: ChatSummary, events: EventWrapper<ChatEvent>[]): boolean {
+export function isUpToDate(chat: ChatSummary, events: EventWrapper<ChatEvent>[]): boolean {
     return (
         chat.latestMessage === undefined ||
         events[events.length - 1]?.index >= chat.latestEventIndex
@@ -76,7 +76,7 @@ export function getRecentlyActiveUsers(
     maxUsers: number
 ): Set<string> {
     const users = new Set<string>();
-    if (upToDate(chat, events)) {
+    if (isUpToDate(chat, events)) {
         const tenMinsAgo = Date.now() - 10 * 60 * 1000;
 
         for (let i = events.length - 1; i >= 0; i--) {


### PR DESCRIPTION
So we will no longer load the latest event window when we send a message and we will not scroll to the bottom unless the events are up to date _and_ we are within the threshold. 

The complication was that we _also_ need to ensure that when we send a message we _do not_ append it to the server event store if doing so would lead to discontiguous ranges. 

fixes #2888 