### PR TITLE
Add small delay between each `upgrade_canisters` invocation

### DIFF
--- a/backend/canisters/group_index/impl/src/jobs/upgrade_canisters.rs
+++ b/backend/canisters/group_index/impl/src/jobs/upgrade_canisters.rs
@@ -17,7 +17,7 @@ pub(crate) fn start_job_if_required(runtime_state: &RuntimeState) -> bool {
         && (runtime_state.data.canisters_requiring_upgrade.count_pending() > 0
             || runtime_state.data.canisters_requiring_upgrade.count_in_progress() > 0)
     {
-        let timer_id = ic_cdk::timer::set_timer_interval(Duration::default(), run);
+        let timer_id = ic_cdk::timer::set_timer_interval(Duration::from_secs(2), run);
         TIMER_ID.with(|t| t.set(Some(timer_id)));
         info!("'upgrade_canisters' job started");
         true

--- a/backend/canisters/local_user_index/impl/src/jobs/upgrade_canisters.rs
+++ b/backend/canisters/local_user_index/impl/src/jobs/upgrade_canisters.rs
@@ -18,7 +18,7 @@ pub(crate) fn start_job_if_required(runtime_state: &RuntimeState) -> bool {
         && (runtime_state.data.canisters_requiring_upgrade.count_pending() > 0
             || runtime_state.data.canisters_requiring_upgrade.count_in_progress() > 0)
     {
-        let timer_id = ic_cdk::timer::set_timer_interval(Duration::default(), run);
+        let timer_id = ic_cdk::timer::set_timer_interval(Duration::from_secs(2), run);
         TIMER_ID.with(|t| t.set(Some(timer_id)));
         info!("'upgrade_canisters' job started");
         true

--- a/backend/canisters/notifications_index/impl/src/jobs/upgrade_canisters.rs
+++ b/backend/canisters/notifications_index/impl/src/jobs/upgrade_canisters.rs
@@ -17,7 +17,7 @@ pub(crate) fn start_job_if_required(runtime_state: &RuntimeState) -> bool {
         && (runtime_state.data.canisters_requiring_upgrade.count_pending() > 0
             || runtime_state.data.canisters_requiring_upgrade.count_in_progress() > 0)
     {
-        let timer_id = ic_cdk::timer::set_timer_interval(Duration::default(), run);
+        let timer_id = ic_cdk::timer::set_timer_interval(Duration::from_secs(2), run);
         TIMER_ID.with(|t| t.set(Some(timer_id)));
         info!("'upgrade_canisters' job started");
         true


### PR DESCRIPTION
This will cause `upgrade_canisters` to be called roughly every other block which will reduce the cost without having much effect on the upgrade speed.