### PR TITLE
Bump cache version since field added to Message

### DIFF
--- a/frontend/openchat-agent/src/utils/caching.ts
+++ b/frontend/openchat-agent/src/utils/caching.ts
@@ -19,7 +19,7 @@ import {
 } from "openchat-shared";
 import type { Principal } from "@dfinity/principal";
 
-const CACHE_VERSION = 56;
+const CACHE_VERSION = 57;
 
 export type Database = Promise<IDBPDatabase<ChatSchema>>;
 


### PR DESCRIPTION
There is a new "deleted" field on a FE Message which gets cached. This will be falsey for all cached messages even those that have been deleted. This causes issues with viewing and undeleting deleted messages.