### PR TITLE
Implement disappearing messages on the backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6269,6 +6269,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-set"
+version = "0.0.9"
+source = "git+https://github.com/hpeebles/range-set?rev=d776de4e38b9d7bf755910da5513c2d8c107bf7e#d776de4e38b9d7bf755910da5513c2d8c107bf7e"
+dependencies = [
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "rayon"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7875,6 +7884,7 @@ dependencies = [
  "human_readable",
  "ic-icrc1",
  "ic-ledger-types",
+ "range-set",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ quote = "1.0.21"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
+range-set = "0.0.9"
 regex = "1.6.0"
 rmp-serde = "1.1.1"
 serde = "1.0.145"
@@ -143,3 +144,4 @@ ic-cdk = { git = "https://github.com/hpeebles/cdk-rs", rev = "f758bf78e6ec18850e
 ic-cdk-macros = { git = "https://github.com/hpeebles/cdk-rs", rev = "f758bf78e6ec18850e6d023c4f60586376d24885" }
 ic-ledger-types = { git = "https://github.com/hpeebles/cdk-rs", rev = "f758bf78e6ec18850e6d023c4f60586376d24885" }
 ic-stable-structures = { git = "https://github.com/hpeebles/stable-structures", rev = "986e0d8531cd152d5da747b760b099f1d4f16136" }
+range-set = { git = "https://github.com/hpeebles/range-set", rev = "d776de4e38b9d7bf755910da5513c2d8c107bf7e" }

--- a/backend/canisters/group/CHANGELOG.md
+++ b/backend/canisters/group/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added `disappears_at` to events ([#3021](https://github.com/open-ic/open-chat/pull/3021)) (website must be released first)
+- Support disappearing messages ([#3029](https://github.com/open-ic/open-chat/pull/3029)) (website must be released first)
 
 ### Changed
 

--- a/backend/canisters/group/api/can.did
+++ b/backend/canisters/group/api/can.did
@@ -359,13 +359,6 @@ type OptionalGroupPermissions =
         reply_in_thread: opt PermissionRole;
     };
 
-type EventsTimeToLiveUpdate =
-    variant {
-        NoChange;
-        SetToNone;
-        SetToSome: Milliseconds;
-    };
-
 type PinMessageArgs =
     record {
         message_index: MessageIndex;

--- a/backend/canisters/group/api/can.did
+++ b/backend/canisters/group/api/can.did
@@ -320,6 +320,7 @@ type UpdateGroupV2Args =
         rules: opt GroupRules;
         avatar: AvatarUpdate;
         permissions: opt OptionalGroupPermissions;
+        events_ttl: EventsTimeToLiveUpdate;
         correlation_id: nat64;
     };
 
@@ -356,6 +357,13 @@ type OptionalGroupPermissions =
         send_messages: opt PermissionRole;
         react_to_messages: opt PermissionRole;
         reply_in_thread: opt PermissionRole;
+    };
+
+type EventsTimeToLiveUpdate =
+    variant {
+        NoChange;
+        SetToNone;
+        SetToSome: Milliseconds;
     };
 
 type PinMessageArgs =

--- a/backend/canisters/group/api/src/lifecycle/init.rs
+++ b/backend/canisters/group/api/src/lifecycle/init.rs
@@ -14,6 +14,7 @@ pub struct Args {
     pub permissions: Option<GroupPermissions>,
     pub created_by_principal: Principal,
     pub created_by_user_id: UserId,
+    pub events_ttl: Option<Milliseconds>,
     pub mark_active_duration: Milliseconds,
     pub user_index_canister_id: CanisterId,
     pub local_user_index_canister_id: CanisterId,

--- a/backend/canisters/group/api/src/updates/update_group_v2.rs
+++ b/backend/canisters/group/api/src/updates/update_group_v2.rs
@@ -1,6 +1,8 @@
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
-use types::{Avatar, FieldTooLongResult, FieldTooShortResult, GroupRules, OptionUpdate, OptionalGroupPermissions};
+use types::{
+    Avatar, FieldTooLongResult, FieldTooShortResult, GroupRules, Milliseconds, OptionUpdate, OptionalGroupPermissions,
+};
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct Args {
@@ -9,6 +11,7 @@ pub struct Args {
     pub rules: Option<GroupRules>,
     pub avatar: OptionUpdate<Avatar>,
     pub permissions: Option<OptionalGroupPermissions>,
+    pub events_ttl: OptionUpdate<Milliseconds>,
     pub correlation_id: u64,
 }
 

--- a/backend/canisters/group/api/src/updates/update_group_v2.rs
+++ b/backend/canisters/group/api/src/updates/update_group_v2.rs
@@ -4,7 +4,7 @@ use types::{
     Avatar, FieldTooLongResult, FieldTooShortResult, GroupRules, Milliseconds, OptionUpdate, OptionalGroupPermissions,
 };
 
-#[derive(CandidType, Serialize, Deserialize, Debug)]
+#[derive(CandidType, Serialize, Deserialize, Debug, Default)]
 pub struct Args {
     pub name: Option<String>,
     pub description: Option<String>,

--- a/backend/canisters/group/impl/src/activity_notifications.rs
+++ b/backend/canisters/group/impl/src/activity_notifications.rs
@@ -49,7 +49,7 @@ pub(crate) fn handle_activity_notification(runtime_state: &mut RuntimeState) {
 
         for event in data
             .events
-            .main_events_reader()
+            .main_events_reader(now)
             .iter(None, false)
             .take_while(|e| e.timestamp >= one_day_ago)
         {

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -120,6 +120,7 @@ impl RuntimeState {
             frozen: data.frozen.value.clone(),
             wasm_version: Version::default(),
             date_last_pinned: data.date_last_pinned,
+            events_ttl: data.events.get_events_time_to_live().value,
         }
     }
 

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -121,6 +121,8 @@ impl RuntimeState {
             wasm_version: Version::default(),
             date_last_pinned: data.date_last_pinned,
             events_ttl: data.events.get_events_time_to_live().value,
+            expired_messages: data.events.expired_messages(now),
+            next_message_expiry: data.events.next_message_expiry(now),
         }
     }
 

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -81,12 +81,11 @@ impl RuntimeState {
         let min_visible_event_index = participant.min_visible_event_index();
         let min_visible_message_index = participant.min_visible_message_index();
         let main_events_reader = data.events.visible_main_events_reader(min_visible_event_index, now);
-        let latest_event_timestamp = main_events_reader.latest_event_timestamp().unwrap_or_default();
         let latest_event_index = main_events_reader.latest_event_index().unwrap_or_default();
 
         GroupCanisterGroupChatSummary {
             chat_id: self.env.canister_id().into(),
-            last_updated: latest_event_timestamp,
+            last_updated: now,
             name: data.name.clone(),
             description: data.description.clone(),
             subtype: data.subtype.value.clone(),

--- a/backend/canisters/group/impl/src/lib.rs
+++ b/backend/canisters/group/impl/src/lib.rs
@@ -76,16 +76,17 @@ impl RuntimeState {
         }
     }
 
-    pub fn summary(&self, participant: &ParticipantInternal) -> GroupCanisterGroupChatSummary {
+    pub fn summary(&self, participant: &ParticipantInternal, now: TimestampMillis) -> GroupCanisterGroupChatSummary {
         let data = &self.data;
         let min_visible_event_index = participant.min_visible_event_index();
         let min_visible_message_index = participant.min_visible_message_index();
-        let main_events_reader = data.events.visible_main_events_reader(min_visible_event_index);
-        let latest_event = main_events_reader.last();
+        let main_events_reader = data.events.visible_main_events_reader(min_visible_event_index, now);
+        let latest_event_timestamp = main_events_reader.latest_event_timestamp().unwrap_or_default();
+        let latest_event_index = main_events_reader.latest_event_index().unwrap_or_default();
 
         GroupCanisterGroupChatSummary {
             chat_id: self.env.canister_id().into(),
-            last_updated: latest_event.timestamp,
+            last_updated: latest_event_timestamp,
             name: data.name.clone(),
             description: data.description.clone(),
             subtype: data.subtype.value.clone(),
@@ -95,11 +96,11 @@ impl RuntimeState {
             min_visible_event_index,
             min_visible_message_index,
             latest_message: main_events_reader.latest_message_event(Some(participant.user_id)),
-            latest_event_index: latest_event.index,
+            latest_event_index,
             joined: participant.date_added,
             participant_count: data.participants.len(),
             role: participant.role,
-            mentions: participant.most_recent_mentions(None, &data.events),
+            mentions: participant.most_recent_mentions(None, &data.events, now),
             owner_id: data.owner_id,
             permissions: data.permissions.clone(),
             notifications_muted: participant.notifications_muted.value,
@@ -114,6 +115,7 @@ impl RuntimeState {
                 participant.threads.iter(),
                 None,
                 MAX_THREADS_IN_SUMMARY,
+                now,
             ),
             frozen: data.frozen.value.clone(),
             wasm_version: Version::default(),
@@ -153,22 +155,24 @@ impl RuntimeState {
         let chat_metrics = self.data.events.metrics();
 
         let now = self.env.now();
-        let messages_in_last_hour = self
+        let messages_in_last_hour = self.data.events.event_count_since(now.saturating_sub(HOUR_IN_MS), now, |e| {
+            matches!(e, ChatEventInternal::Message(_))
+        }) as u64;
+        let messages_in_last_day = self.data.events.event_count_since(now.saturating_sub(DAY_IN_MS), now, |e| {
+            matches!(e, ChatEventInternal::Message(_))
+        }) as u64;
+        let events_in_last_hour = self
             .data
             .events
-            .event_count_since(now.saturating_sub(HOUR_IN_MS), |e| matches!(e, ChatEventInternal::Message(_)))
-            as u64;
-        let messages_in_last_day = self
+            .event_count_since(now.saturating_sub(HOUR_IN_MS), now, |_| true) as u64;
+        let events_in_last_day = self
             .data
             .events
-            .event_count_since(now.saturating_sub(DAY_IN_MS), |e| matches!(e, ChatEventInternal::Message(_)))
-            as u64;
-        let events_in_last_hour = self.data.events.event_count_since(now.saturating_sub(HOUR_IN_MS), |_| true) as u64;
-        let events_in_last_day = self.data.events.event_count_since(now.saturating_sub(DAY_IN_MS), |_| true) as u64;
+            .event_count_since(now.saturating_sub(DAY_IN_MS), now, |_| true) as u64;
 
         Metrics {
             memory_used: memory::used(),
-            now: self.env.now(),
+            now,
             cycles_balance: self.env.cycles_balance(),
             wasm_version: WASM_VERSION.with(|v| **v.borrow()),
             git_commit_id: utils::git::git_commit_id().to_string(),
@@ -257,6 +261,7 @@ impl Data {
         history_visible_to_new_joiners: bool,
         creator_principal: Principal,
         creator_user_id: UserId,
+        events_ttl: Option<Milliseconds>,
         now: TimestampMillis,
         mark_active_duration: Milliseconds,
         group_index_canister_id: CanisterId,
@@ -269,7 +274,7 @@ impl Data {
         permissions: Option<GroupPermissions>,
     ) -> Data {
         let participants = Participants::new(creator_principal, creator_user_id, now);
-        let events = ChatEvents::new_group_chat(chat_id, name.clone(), description.clone(), creator_user_id, now);
+        let events = ChatEvents::new_group_chat(chat_id, name.clone(), description.clone(), creator_user_id, events_ttl, now);
 
         Data {
             is_public,

--- a/backend/canisters/group/impl/src/lifecycle/init.rs
+++ b/backend/canisters/group/impl/src/lifecycle/init.rs
@@ -26,6 +26,7 @@ fn init(args: Args) {
         args.history_visible_to_new_joiners,
         args.created_by_principal,
         args.created_by_user_id,
+        args.events_ttl,
         env.now(),
         args.mark_active_duration,
         args.group_index_canister_id,

--- a/backend/canisters/group/impl/src/model/participants.rs
+++ b/backend/canisters/group/impl/src/model/participants.rs
@@ -403,12 +403,17 @@ impl ParticipantInternal {
         }
     }
 
-    pub fn most_recent_mentions(&self, since: Option<TimestampMillis>, chat_events: &ChatEvents) -> Vec<Mention> {
+    pub fn most_recent_mentions(
+        &self,
+        since: Option<TimestampMillis>,
+        chat_events: &ChatEvents,
+        now: TimestampMillis,
+    ) -> Vec<Mention> {
         let min_visible_event_index = self.min_visible_event_index();
 
         self.mentions_v2
             .iter_most_recent(since)
-            .filter_map(|m| chat_events.hydrate_mention(min_visible_event_index, m))
+            .filter_map(|m| chat_events.hydrate_mention(min_visible_event_index, m, now))
             .take(MAX_RETURNED_MENTIONS)
             .collect()
     }

--- a/backend/canisters/group/impl/src/queries/deleted_message.rs
+++ b/backend/canisters/group/impl/src/queries/deleted_message.rs
@@ -17,10 +17,13 @@ fn deleted_message_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     };
 
     if let Some(min_visible_event_index) = runtime_state.data.min_visible_event_index(caller, None) {
-        if let Some(events_reader) = runtime_state
-            .data
-            .events
-            .events_reader(min_visible_event_index, args.thread_root_message_index)
+        let now = runtime_state.env.now();
+
+        if let Some(events_reader) =
+            runtime_state
+                .data
+                .events
+                .events_reader(min_visible_event_index, args.thread_root_message_index, now)
         {
             if let Some(message) = events_reader.message_internal(args.message_id.into()) {
                 if let Some(deleted_by) = &message.deleted_by {

--- a/backend/canisters/group/impl/src/queries/events.rs
+++ b/backend/canisters/group/impl/src/queries/events.rs
@@ -12,10 +12,13 @@ fn events_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     let caller = runtime_state.env.caller();
 
     if let Some(min_visible_event_index) = runtime_state.data.min_visible_event_index(caller, args.invite_code) {
-        if let Some(events_reader) = runtime_state
-            .data
-            .events
-            .events_reader(min_visible_event_index, args.thread_root_message_index)
+        let now = runtime_state.env.now();
+
+        if let Some(events_reader) =
+            runtime_state
+                .data
+                .events
+                .events_reader(min_visible_event_index, args.thread_root_message_index, now)
         {
             let latest_event_index = events_reader.latest_event_index().unwrap();
 

--- a/backend/canisters/group/impl/src/queries/events_by_index.rs
+++ b/backend/canisters/group/impl/src/queries/events_by_index.rs
@@ -10,11 +10,15 @@ fn events_by_index(args: Args) -> Response {
 
 fn events_by_index_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     let caller = runtime_state.env.caller();
+
     if let Some(min_visible_event_index) = runtime_state.data.min_visible_event_index(caller, args.invite_code) {
-        if let Some(events_reader) = runtime_state
-            .data
-            .events
-            .events_reader(min_visible_event_index, args.thread_root_message_index)
+        let now = runtime_state.env.now();
+
+        if let Some(events_reader) =
+            runtime_state
+                .data
+                .events
+                .events_reader(min_visible_event_index, args.thread_root_message_index, now)
         {
             let latest_event_index = events_reader.latest_event_index().unwrap();
 

--- a/backend/canisters/group/impl/src/queries/events_window.rs
+++ b/backend/canisters/group/impl/src/queries/events_window.rs
@@ -10,11 +10,15 @@ fn events_window(args: Args) -> Response {
 
 fn events_window_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     let caller = runtime_state.env.caller();
+
     if let Some(min_visible_event_index) = runtime_state.data.min_visible_event_index(caller, args.invite_code) {
-        if let Some(events_reader) = runtime_state
-            .data
-            .events
-            .events_reader(min_visible_event_index, args.thread_root_message_index)
+        let now = runtime_state.env.now();
+
+        if let Some(events_reader) =
+            runtime_state
+                .data
+                .events
+                .events_reader(min_visible_event_index, args.thread_root_message_index, now)
         {
             let latest_event_index = events_reader.latest_event_index().unwrap();
 

--- a/backend/canisters/group/impl/src/queries/messages_by_message_index.rs
+++ b/backend/canisters/group/impl/src/queries/messages_by_message_index.rs
@@ -10,11 +10,15 @@ fn messages_by_message_index(args: Args) -> Response {
 
 fn messages_by_message_index_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     let caller = runtime_state.env.caller();
+
     if let Some(min_visible_event_index) = runtime_state.data.min_visible_event_index(caller, args.invite_code) {
-        if let Some(events_reader) = runtime_state
-            .data
-            .events
-            .events_reader(min_visible_event_index, args.thread_root_message_index)
+        let now = runtime_state.env.now();
+
+        if let Some(events_reader) =
+            runtime_state
+                .data
+                .events
+                .events_reader(min_visible_event_index, args.thread_root_message_index, now)
         {
             let latest_event_index = events_reader.latest_event_index().unwrap();
 

--- a/backend/canisters/group/impl/src/queries/public_summary.rs
+++ b/backend/canisters/group/impl/src/queries/public_summary.rs
@@ -15,19 +15,21 @@ fn public_summary_impl(args: Args, runtime_state: &RuntimeState) -> Response {
         return NotAuthorized;
     }
 
+    let now = runtime_state.env.now();
     let data = &runtime_state.data;
-    let events_reader = runtime_state.data.events.main_events_reader();
-    let latest_event = events_reader.last();
+    let events_reader = runtime_state.data.events.main_events_reader(now);
+    let latest_event_timestamp = events_reader.latest_event_timestamp().unwrap_or_default();
+    let latest_event_index = events_reader.latest_event_index().unwrap_or_default();
 
     let summary = PublicGroupSummary {
         chat_id: runtime_state.env.canister_id().into(),
-        last_updated: latest_event.timestamp,
+        last_updated: latest_event_timestamp,
         name: data.name.clone(),
         description: data.description.clone(),
         subtype: data.subtype.value.clone(),
         avatar_id: Avatar::id(&data.avatar),
         latest_message: events_reader.latest_message_event(None),
-        latest_event_index: latest_event.index,
+        latest_event_index,
         participant_count: data.participants.len(),
         owner_id: runtime_state.data.owner_id,
         is_public: runtime_state.data.is_public,

--- a/backend/canisters/group/impl/src/queries/public_summary.rs
+++ b/backend/canisters/group/impl/src/queries/public_summary.rs
@@ -34,6 +34,7 @@ fn public_summary_impl(args: Args, runtime_state: &RuntimeState) -> Response {
         owner_id: runtime_state.data.owner_id,
         is_public: runtime_state.data.is_public,
         frozen: runtime_state.data.frozen.value.clone(),
+        events_ttl: runtime_state.data.events.get_events_time_to_live().value,
         wasm_version: Version::default(),
     };
     Success(SuccessResult { summary })

--- a/backend/canisters/group/impl/src/queries/selected_initial.rs
+++ b/backend/canisters/group/impl/src/queries/selected_initial.rs
@@ -10,11 +10,17 @@ fn selected_initial(_args: Args) -> Response {
 fn selected_initial_impl(runtime_state: &RuntimeState) -> Response {
     let caller = runtime_state.env.caller();
     if let Some(participant) = runtime_state.data.participants.get(caller) {
+        let now = runtime_state.env.now();
         let min_visible_message_index = participant.min_visible_message_index();
         let participants = &runtime_state.data.participants;
 
         Success(SuccessResult {
-            latest_event_index: runtime_state.data.events.main_events_reader().latest_event_index().unwrap(),
+            latest_event_index: runtime_state
+                .data
+                .events
+                .main_events_reader(now)
+                .latest_event_index()
+                .unwrap(),
             participants: participants.iter().map(|p| p.into()).collect(),
             blocked_users: participants.blocked(),
             pinned_messages: runtime_state

--- a/backend/canisters/group/impl/src/queries/selected_initial.rs
+++ b/backend/canisters/group/impl/src/queries/selected_initial.rs
@@ -20,7 +20,7 @@ fn selected_initial_impl(runtime_state: &RuntimeState) -> Response {
                 .events
                 .main_events_reader(now)
                 .latest_event_index()
-                .unwrap(),
+                .unwrap_or_default(),
             participants: participants.iter().map(|p| p.into()).collect(),
             blocked_users: participants.blocked(),
             pinned_messages: runtime_state

--- a/backend/canisters/group/impl/src/queries/selected_updates.rs
+++ b/backend/canisters/group/impl/src/queries/selected_updates.rs
@@ -18,8 +18,9 @@ fn selected_updates_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     };
 
     let min_visible_event_index = participant.min_visible_event_index();
+    let now = runtime_state.env.now();
     let data = &runtime_state.data;
-    let events_reader = data.events.visible_main_events_reader(min_visible_event_index);
+    let events_reader = data.events.visible_main_events_reader(min_visible_event_index, now);
     let latest_event_index = events_reader.latest_event_index().unwrap();
 
     if latest_event_index <= args.updates_since {

--- a/backend/canisters/group/impl/src/queries/summary.rs
+++ b/backend/canisters/group/impl/src/queries/summary.rs
@@ -17,7 +17,8 @@ fn c2c_summary(_: Args) -> Response {
 fn summary_impl(runtime_state: &RuntimeState) -> Response {
     let caller = runtime_state.env.caller();
     if let Some(participant) = runtime_state.data.participants.get(caller) {
-        let summary = runtime_state.summary(participant);
+        let now = runtime_state.env.now();
+        let summary = runtime_state.summary(participant, now);
         Success(SuccessResult { summary })
     } else {
         CallerNotInGroup

--- a/backend/canisters/group/impl/src/timer_job_types.rs
+++ b/backend/canisters/group/impl/src/timer_job_types.rs
@@ -34,10 +34,13 @@ impl Job for TimerJob {
 impl Job for HardDeleteMessageContentJob {
     fn execute(&self) {
         mutate_state(|state| {
-            if let Some(content) = state
-                .data
-                .events
-                .remove_deleted_message_content(self.thread_root_message_index, self.message_id)
+            let now = state.env.now();
+
+            if let Some(content) =
+                state
+                    .data
+                    .events
+                    .remove_deleted_message_content(self.thread_root_message_index, self.message_id, now)
             {
                 let files_to_delete = content.blob_references();
                 if !files_to_delete.is_empty() {

--- a/backend/canisters/group/impl/src/timer_job_types.rs
+++ b/backend/canisters/group/impl/src/timer_job_types.rs
@@ -2,11 +2,12 @@ use crate::activity_notifications::handle_activity_notification;
 use crate::mutate_state;
 use canister_timer_jobs::Job;
 use serde::{Deserialize, Serialize};
-use types::{MessageId, MessageIndex};
+use types::{BlobReference, MessageId, MessageIndex};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub enum TimerJob {
     HardDeleteMessageContent(HardDeleteMessageContentJob),
+    DeleteFileReferences(DeleteFileReferencesJob),
     EndPoll(EndPollJob),
 }
 
@@ -14,6 +15,11 @@ pub enum TimerJob {
 pub struct HardDeleteMessageContentJob {
     pub thread_root_message_index: Option<MessageIndex>,
     pub message_id: MessageId,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DeleteFileReferencesJob {
+    pub files: Vec<BlobReference>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -26,6 +32,7 @@ impl Job for TimerJob {
     fn execute(&self) {
         match self {
             TimerJob::HardDeleteMessageContent(job) => job.execute(),
+            TimerJob::DeleteFileReferences(job) => job.execute(),
             TimerJob::EndPoll(job) => job.execute(),
         }
     }
@@ -44,10 +51,24 @@ impl Job for HardDeleteMessageContentJob {
             {
                 let files_to_delete = content.blob_references();
                 if !files_to_delete.is_empty() {
+                    // If there was already a job queued up to delete these files, cancel it
+                    state.data.timer_jobs.cancel_jobs(|job| {
+                        if let TimerJob::DeleteFileReferences(j) = job {
+                            j.files.iter().all(|f| files_to_delete.contains(f))
+                        } else {
+                            false
+                        }
+                    });
                     ic_cdk::spawn(open_storage_bucket_client::delete_files(files_to_delete));
                 }
             }
         });
+    }
+}
+
+impl Job for DeleteFileReferencesJob {
+    fn execute(&self) {
+        ic_cdk::spawn(open_storage_bucket_client::delete_files(self.files.clone()));
     }
 }
 

--- a/backend/canisters/group/impl/src/updates/add_participants.rs
+++ b/backend/canisters/group/impl/src/updates/add_participants.rs
@@ -141,9 +141,11 @@ fn prepare(args: &Args, runtime_state: &RuntimeState) -> Result<PrepareResult, B
             return Err(Box::new(NotAuthorized));
         }
 
+        let now = runtime_state.env.now();
+
         Ok(PrepareResult {
             added_by: participant.user_id,
-            latest_message_index: runtime_state.data.events.main_events_reader().latest_message_index(),
+            latest_message_index: runtime_state.data.events.main_events_reader(now).latest_message_index(),
             users_to_add,
             users_already_in_group,
             users_blocked_from_group,
@@ -167,7 +169,7 @@ fn commit(
     if !runtime_state.data.history_visible_to_new_joiners {
         // If there is only an initial "group created" event then allow these initial
         // participants to see the "group created" event by starting min_visible_* at zero
-        let events_reader = runtime_state.data.events.main_events_reader();
+        let events_reader = runtime_state.data.events.main_events_reader(now);
         if events_reader.len() > 1 {
             min_visible_event_index = events_reader.next_event_index();
             min_visible_message_index = events_reader.next_message_index();

--- a/backend/canisters/group/impl/src/updates/add_reaction.rs
+++ b/backend/canisters/group/impl/src/updates/add_reaction.rs
@@ -73,7 +73,7 @@ fn handle_notification(
     if let Some(message) = runtime_state
         .data
         .events
-        .events_reader(EventIndex::default(), thread_root_message_index)
+        .events_reader(EventIndex::default(), thread_root_message_index, now)
         // We pass in `None` in place of `my_user_id` because we don't want to hydrate
         // the notification with data for the current user (eg. their poll votes).
         .and_then(|events_reader| events_reader.message_event(message_id.into(), None))

--- a/backend/canisters/group/impl/src/updates/c2c_join_group.rs
+++ b/backend/canisters/group/impl/src/updates/c2c_join_group.rs
@@ -31,7 +31,7 @@ fn c2c_join_group_impl(args: Args, runtime_state: &mut RuntimeState) -> Response
             min_visible_event_index = EventIndex::default();
             min_visible_message_index = MessageIndex::default();
         } else {
-            let events_reader = runtime_state.data.events.main_events_reader();
+            let events_reader = runtime_state.data.events.main_events_reader(now);
             min_visible_event_index = events_reader.next_event_index();
             min_visible_message_index = events_reader.next_message_index();
         };
@@ -58,7 +58,7 @@ fn c2c_join_group_impl(args: Args, runtime_state: &mut RuntimeState) -> Response
 
                 handle_activity_notification(runtime_state);
 
-                let summary = runtime_state.summary(&participant);
+                let summary = runtime_state.summary(&participant, now);
                 Success(Box::new(summary))
             }
             AddResult::AlreadyInGroup => AlreadyInGroup,

--- a/backend/canisters/group/impl/src/updates/delete_messages.rs
+++ b/backend/canisters/group/impl/src/updates/delete_messages.rs
@@ -2,7 +2,7 @@ use crate::activity_notifications::handle_activity_notification;
 use crate::timer_job_types::HardDeleteMessageContentJob;
 use crate::{mutate_state, run_regular_jobs, RuntimeState, TimerJob};
 use canister_tracing_macros::trace;
-use chat_events::{ChatEventInternal, DeleteMessageResult, DeleteUndeleteMessagesArgs, EventKey, Reader};
+use chat_events::{ChatEventInternal, DeleteMessageResult, DeleteUndeleteMessagesArgs, Reader};
 use group_canister::delete_messages::{Response::*, *};
 use ic_cdk_macros::update;
 use std::collections::HashSet;
@@ -30,15 +30,7 @@ fn delete_messages_impl(args: Args, runtime_state: &mut RuntimeState) -> Respons
 
         let now = runtime_state.env.now();
         let user_id = participant.user_id;
-
         let min_visible_event_index = participant.min_visible_event_index();
-        if !runtime_state.data.events.are_messages_accessible(
-            min_visible_event_index,
-            args.thread_root_message_index,
-            args.message_ids.iter().copied().map(EventKey::MessageId).collect(),
-        ) {
-            return MessageNotFound;
-        }
 
         let mut my_messages: HashSet<MessageId> = HashSet::new();
 
@@ -47,7 +39,7 @@ fn delete_messages_impl(args: Args, runtime_state: &mut RuntimeState) -> Respons
                 if let Some((message_index, sender)) = runtime_state
                     .data
                     .events
-                    .visible_main_events_reader(min_visible_event_index)
+                    .visible_main_events_reader(min_visible_event_index, now)
                     .message_internal(message_id.into())
                     .map(|m| (m.message_index, m.sender))
                 {

--- a/backend/canisters/group/impl/src/updates/pin_message.rs
+++ b/backend/canisters/group/impl/src/updates/pin_message.rs
@@ -28,17 +28,18 @@ fn pin_message_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
             return NotAuthorized;
         }
 
+        let now = runtime_state.env.now();
+        let min_visible_event_index = participant.min_visible_event_index();
+
         if !runtime_state
             .data
             .events
-            .is_accessible(participant.min_visible_event_index(), None, args.message_index.into())
+            .is_accessible(min_visible_event_index, None, args.message_index.into(), now)
         {
             return MessageNotFound;
         }
 
         if let Err(index) = runtime_state.data.pinned_messages.binary_search(&args.message_index) {
-            let now = runtime_state.env.now();
-
             runtime_state.data.pinned_messages.insert(index, args.message_index);
 
             let push_event_result = runtime_state.data.events.push_main_event(

--- a/backend/canisters/group/impl/src/updates/send_message.rs
+++ b/backend/canisters/group/impl/src/updates/send_message.rs
@@ -1,14 +1,15 @@
 use crate::activity_notifications::handle_activity_notification;
-use crate::timer_job_types::EndPollJob;
+use crate::timer_job_types::{DeleteFileReferencesJob, EndPollJob};
 use crate::{mutate_state, run_regular_jobs, RuntimeState, TimerJob};
 use canister_api_macros::update_candid_and_msgpack;
+use canister_timer_jobs::TimerJobs;
 use canister_tracing_macros::trace;
 use chat_events::{PushMessageArgs, Reader};
 use group_canister::send_message::{Response::*, *};
 use std::collections::HashSet;
 use types::{
-    ContentValidationError, EventIndex, EventWrapper, GroupMessageNotification, GroupReplyContext, MentionInternal, Message,
-    MessageContent, MessageIndex, Notification, TimestampMillis, UserId,
+    BlobReference, ContentValidationError, EventIndex, EventWrapper, GroupMessageNotification, GroupReplyContext,
+    MentionInternal, Message, MessageContent, MessageIndex, Notification, TimestampMillis, UserId,
 };
 
 #[update_candid_and_msgpack]
@@ -76,12 +77,14 @@ fn send_message_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
         let user_being_replied_to = args.replies_to.as_ref().and_then(|r| {
             get_user_being_replied_to(r, min_visible_event_index, args.thread_root_message_index, now, runtime_state)
         });
+        let content = args.content.new_content_into_internal();
+        let files = content.blob_references();
 
         let push_message_args = PushMessageArgs {
             sender,
             thread_root_message_index: args.thread_root_message_index,
             message_id: args.message_id,
-            content: args.content.new_content_into_internal(),
+            content,
             replies_to: args.replies_to.map(|r| r.into()),
             forwarded: args.forwarding,
             correlation_id: args.correlation_id,
@@ -90,7 +93,13 @@ fn send_message_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
 
         let message_event = runtime_state.data.events.push_message(push_message_args);
 
-        register_jobs_if_required(args.thread_root_message_index, &message_event, runtime_state);
+        register_timer_jobs(
+            args.thread_root_message_index,
+            &message_event,
+            files,
+            now,
+            &mut runtime_state.data.timer_jobs,
+        );
 
         let event_index = message_event.index;
         let message_index = message_event.event.message_index;
@@ -176,20 +185,32 @@ fn send_message_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
     }
 }
 
-fn register_jobs_if_required(
+fn register_timer_jobs(
     thread_root_message_index: Option<MessageIndex>,
     message_event: &EventWrapper<Message>,
-    runtime_state: &mut RuntimeState,
+    file_references: Vec<BlobReference>,
+    now: TimestampMillis,
+    timer_jobs: &mut TimerJobs<TimerJob>,
 ) {
     if let MessageContent::Poll(p) = &message_event.event.content {
         if let Some(end_date) = p.config.end_date {
-            runtime_state.data.timer_jobs.enqueue_job(
+            timer_jobs.enqueue_job(
                 TimerJob::EndPoll(EndPollJob {
                     thread_root_message_index,
                     message_index: message_event.event.message_index,
                 }),
                 end_date,
-                runtime_state.env.now(),
+                now,
+            );
+        }
+    }
+
+    if !file_references.is_empty() {
+        if let Some(expiry) = message_event.expires_at {
+            timer_jobs.enqueue_job(
+                TimerJob::DeleteFileReferences(DeleteFileReferencesJob { files: file_references }),
+                expiry,
+                now,
             );
         }
     }

--- a/backend/canisters/group/impl/src/updates/unpin_message.rs
+++ b/backend/canisters/group/impl/src/updates/unpin_message.rs
@@ -28,17 +28,17 @@ fn unpin_message_impl(args: Args, runtime_state: &mut RuntimeState) -> Response 
             return NotAuthorized;
         }
 
+        let now = runtime_state.env.now();
+
         if !runtime_state
             .data
             .events
-            .is_accessible(participant.min_visible_event_index(), None, args.message_index.into())
+            .is_accessible(participant.min_visible_event_index(), None, args.message_index.into(), now)
         {
             return MessageNotFound;
         }
 
         if let Ok(index) = runtime_state.data.pinned_messages.binary_search(&args.message_index) {
-            let now = runtime_state.env.now();
-
             runtime_state.data.pinned_messages.remove(index);
 
             let push_event_result = runtime_state.data.events.push_main_event(

--- a/backend/canisters/group/impl/src/updates/update_group_v2.rs
+++ b/backend/canisters/group/impl/src/updates/update_group_v2.rs
@@ -235,7 +235,7 @@ fn commit(my_user_id: UserId, args: Args, runtime_state: &mut RuntimeState) {
     }
 
     if let Some(new_events_ttl) = args.events_ttl.expand() {
-        if new_events_ttl != runtime_state.data.events.get_events_time_to_live() {
+        if new_events_ttl != runtime_state.data.events.get_events_time_to_live().value {
             runtime_state
                 .data
                 .events

--- a/backend/canisters/group/impl/src/updates/update_group_v2.rs
+++ b/backend/canisters/group/impl/src/updates/update_group_v2.rs
@@ -234,6 +234,15 @@ fn commit(my_user_id: UserId, args: Args, runtime_state: &mut RuntimeState) {
         );
     }
 
+    if let Some(new_events_ttl) = args.events_ttl.expand() {
+        if new_events_ttl != runtime_state.data.events.get_events_time_to_live() {
+            runtime_state
+                .data
+                .events
+                .set_events_time_to_live(my_user_id, new_events_ttl, now);
+        }
+    }
+
     handle_activity_notification(runtime_state);
 }
 

--- a/backend/canisters/group_index/CHANGELOG.md
+++ b/backend/canisters/group_index/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Added `events_ttl` field to `c2c_create_group` args for setting the 'time to live' for disappearing messages ([#3029](https://github.com/open-ic/open-chat/pull/3029))
+
 ### Removed
 
 - Removed code only needed for the previous upgrade ([#3003](https://github.com/open-ic/open-chat/pull/3003))

--- a/backend/canisters/group_index/api/src/updates/c2c_create_group.rs
+++ b/backend/canisters/group_index/api/src/updates/c2c_create_group.rs
@@ -1,6 +1,6 @@
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
-use types::{Avatar, ChatId, GroupPermissions, GroupRules, GroupSubtype};
+use types::{Avatar, ChatId, GroupPermissions, GroupRules, GroupSubtype, Milliseconds};
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct Args {
@@ -12,6 +12,7 @@ pub struct Args {
     pub avatar: Option<Avatar>,
     pub history_visible_to_new_joiners: bool,
     pub permissions: Option<GroupPermissions>,
+    pub events_ttl: Option<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]

--- a/backend/canisters/group_index/impl/src/model/cached_hot_groups.rs
+++ b/backend/canisters/group_index/impl/src/model/cached_hot_groups.rs
@@ -2,7 +2,7 @@ use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use tracing::trace;
-use types::{ChatId, EventIndex, EventWrapper, Message, PublicGroupSummary, TimestampMillis, UserId};
+use types::{ChatId, EventIndex, EventWrapper, Message, Milliseconds, PublicGroupSummary, TimestampMillis, UserId};
 
 #[derive(CandidType, Serialize, Deserialize, Default)]
 pub struct CachedHotGroups {
@@ -42,6 +42,8 @@ pub struct CachedPublicGroupSummary {
     pub latest_event_index: EventIndex,
     pub participant_count: u32,
     pub owner_id: UserId,
+    #[serde(default)]
+    pub events_ttl: Option<Milliseconds>,
 }
 
 impl From<PublicGroupSummary> for CachedPublicGroupSummary {
@@ -53,6 +55,7 @@ impl From<PublicGroupSummary> for CachedPublicGroupSummary {
             latest_event_index: summary.latest_event_index,
             participant_count: summary.participant_count,
             owner_id: summary.owner_id,
+            events_ttl: summary.events_ttl,
         }
     }
 }

--- a/backend/canisters/group_index/impl/src/model/public_groups.rs
+++ b/backend/canisters/group_index/impl/src/model/public_groups.rs
@@ -103,6 +103,7 @@ impl PublicGroups {
             owner_id: summary.owner_id,
             is_public: true,
             frozen: None,
+            events_ttl: summary.events_ttl,
             wasm_version: Version::default(),
         })
     }

--- a/backend/canisters/group_index/impl/src/updates/c2c_create_group.rs
+++ b/backend/canisters/group_index/impl/src/updates/c2c_create_group.rs
@@ -34,6 +34,7 @@ async fn c2c_create_group(args: Args) -> Response {
         avatar: args.avatar,
         history_visible_to_new_joiners: args.history_visible_to_new_joiners,
         permissions: args.permissions,
+        events_ttl: args.events_ttl,
     };
 
     match local_group_index_canister_c2c_client::c2c_create_group(local_group_index_canister, &c2c_create_group_args).await {

--- a/backend/canisters/local_group_index/CHANGELOG.md
+++ b/backend/canisters/local_group_index/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Added
+
+- Added `events_ttl` field to `c2c_create_group` args for setting the 'time to live' for disappearing messages ([#3029](https://github.com/open-ic/open-chat/pull/3029))
+
 ### Removed
 
 - Removed code only needed for the previous upgrade ([#3003](https://github.com/open-ic/open-chat/pull/3003))

--- a/backend/canisters/local_group_index/api/src/updates/c2c_create_group.rs
+++ b/backend/canisters/local_group_index/api/src/updates/c2c_create_group.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
-use types::{Avatar, ChatId, GroupPermissions, GroupRules, GroupSubtype, UserId};
+use types::{Avatar, ChatId, GroupPermissions, GroupRules, GroupSubtype, Milliseconds, UserId};
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct Args {
@@ -14,6 +14,7 @@ pub struct Args {
     pub avatar: Option<Avatar>,
     pub history_visible_to_new_joiners: bool,
     pub permissions: Option<GroupPermissions>,
+    pub events_ttl: Option<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]

--- a/backend/canisters/local_group_index/impl/src/updates/c2c_create_group.rs
+++ b/backend/canisters/local_group_index/impl/src/updates/c2c_create_group.rs
@@ -74,6 +74,7 @@ fn prepare(args: Args, runtime_state: &mut RuntimeState) -> Result<PrepareOk, Re
         permissions: args.permissions,
         created_by_principal: args.created_by_user_principal,
         created_by_user_id: args.created_by_user_id,
+        events_ttl: args.events_ttl,
         mark_active_duration: MARK_ACTIVE_DURATION,
         wasm_version: canister_wasm.version,
         group_index_canister_id: runtime_state.data.group_index_canister_id,

--- a/backend/canisters/proposals_bot/impl/src/updates/add_governance_canister.rs
+++ b/backend/canisters/proposals_bot/impl/src/updates/add_governance_canister.rs
@@ -63,6 +63,7 @@ async fn create_group(args: &Args, is_nns: bool) -> Result<ChatId, Response> {
             send_messages: PermissionRole::Admins,
             ..Default::default()
         }),
+        events_ttl: None,
     };
     match group_index_canister_c2c_client::c2c_create_group(group_index_canister_id, &create_group_args).await {
         Ok(group_index_canister::c2c_create_group::Response::Success(result)) => Ok(result.chat_id),

--- a/backend/canisters/user/CHANGELOG.md
+++ b/backend/canisters/user/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added `disappears_at` to events ([#3021](https://github.com/open-ic/open-chat/pull/3021)) (website must be released first)
+- Support disappearing messages ([#3029](https://github.com/open-ic/open-chat/pull/3029)) (website must be released first)
 
 ### Changed
 

--- a/backend/canisters/user/api/src/updates/create_group.rs
+++ b/backend/canisters/user/api/src/updates/create_group.rs
@@ -1,6 +1,8 @@
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
-use types::{Avatar, ChatId, FieldTooLongResult, FieldTooShortResult, GroupPermissions, GroupRules, GroupSubtype};
+use types::{
+    Avatar, ChatId, FieldTooLongResult, FieldTooShortResult, GroupPermissions, GroupRules, GroupSubtype, Milliseconds,
+};
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct Args {
@@ -12,6 +14,7 @@ pub struct Args {
     pub avatar: Option<Avatar>,
     pub history_visible_to_new_joiners: bool,
     pub permissions: Option<GroupPermissions>,
+    pub events_ttl: Option<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -90,6 +90,7 @@ impl DirectChat {
             metrics: self.events.metrics().clone(),
             my_metrics: self.events.user_metrics(&my_user_id, None).cloned().unwrap_or_default(),
             archived: self.archived.value,
+            events_ttl: self.events.get_events_time_to_live().value,
         }
     }
 

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -2,7 +2,8 @@ use crate::model::unread_message_index_map::UnreadMessageIndexMap;
 use chat_events::{ChatEvents, Reader};
 use serde::{Deserialize, Serialize};
 use types::{
-    DirectChatSummary, DirectChatSummaryUpdates, MessageId, MessageIndex, Milliseconds, TimestampMillis, Timestamped, UserId,
+    DirectChatSummary, DirectChatSummaryUpdates, MessageId, MessageIndex, Milliseconds, OptionUpdate, TimestampMillis,
+    Timestamped, UserId,
 };
 use user_canister::c2c_send_messages::SendMessageArgs;
 
@@ -118,6 +119,12 @@ impl DirectChat {
             metrics,
             my_metrics: self.events.user_metrics(&my_user_id, Some(updates_since)).cloned(),
             archived: self.archived.if_set_after(updates_since).copied(),
+            events_ttl: self
+                .events
+                .get_events_time_to_live()
+                .if_set_after(updates_since)
+                .copied()
+                .map_or(OptionUpdate::NoChange, OptionUpdate::from_update),
         }
     }
 }

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -1,7 +1,9 @@
 use crate::model::unread_message_index_map::UnreadMessageIndexMap;
 use chat_events::{ChatEvents, Reader};
 use serde::{Deserialize, Serialize};
-use types::{DirectChatSummary, DirectChatSummaryUpdates, MessageId, MessageIndex, TimestampMillis, Timestamped, UserId};
+use types::{
+    DirectChatSummary, DirectChatSummaryUpdates, MessageId, MessageIndex, Milliseconds, TimestampMillis, Timestamped, UserId,
+};
 use user_canister::c2c_send_messages::SendMessageArgs;
 
 #[derive(Serialize, Deserialize)]
@@ -19,11 +21,11 @@ pub struct DirectChat {
 }
 
 impl DirectChat {
-    pub fn new(them: UserId, is_bot: bool, now: TimestampMillis) -> DirectChat {
+    pub fn new(them: UserId, is_bot: bool, events_ttl: Option<Milliseconds>, now: TimestampMillis) -> DirectChat {
         DirectChat {
             them,
             date_created: now,
-            events: ChatEvents::new_direct_chat(them, now),
+            events: ChatEvents::new_direct_chat(them, events_ttl, now),
             unread_message_index_map: UnreadMessageIndexMap::default(),
             read_by_me_up_to: Timestamped::new(None, now),
             read_by_them_up_to: Timestamped::new(None, now),
@@ -34,9 +36,12 @@ impl DirectChat {
         }
     }
 
-    pub fn last_updated(&self) -> TimestampMillis {
+    pub fn last_updated(&self, now: TimestampMillis) -> TimestampMillis {
         let timestamps = [
-            self.events.main_events_reader().last().timestamp,
+            self.events
+                .main_events_reader(now)
+                .latest_event_timestamp()
+                .unwrap_or_default(),
             self.read_by_me_up_to.timestamp,
             self.read_by_them_up_to.timestamp,
             self.notifications_muted.timestamp,
@@ -70,8 +75,8 @@ impl DirectChat {
         self.unconfirmed_v2.retain(|m| m.message_id != message_id);
     }
 
-    pub fn to_summary(&self, my_user_id: UserId) -> DirectChatSummary {
-        let events_reader = self.events.main_events_reader();
+    pub fn to_summary(&self, my_user_id: UserId, now: TimestampMillis) -> DirectChatSummary {
+        let events_reader = self.events.main_events_reader(now);
 
         DirectChatSummary {
             them: self.them,
@@ -87,16 +92,20 @@ impl DirectChat {
         }
     }
 
-    pub fn to_summary_updates(&self, updates_since: TimestampMillis, my_user_id: UserId) -> DirectChatSummaryUpdates {
-        let events_reader = self.events.main_events_reader();
+    pub fn to_summary_updates(
+        &self,
+        updates_since: TimestampMillis,
+        my_user_id: UserId,
+        now: TimestampMillis,
+    ) -> DirectChatSummaryUpdates {
+        let events_reader = self.events.main_events_reader(now);
 
+        let has_new_events = events_reader.latest_event_timestamp().map_or(false, |ts| ts > updates_since);
         let latest_message = events_reader.latest_message_event_if_updated(updates_since, Some(my_user_id));
-        let latest_event = events_reader.last();
-        let has_new_events = latest_event.timestamp > updates_since;
-        let latest_event_index = if has_new_events { Some(latest_event.index) } else { None };
-        let metrics = if has_new_events { Some(self.events.metrics().clone()) } else { None };
+        let latest_event_index = if has_new_events { events_reader.latest_event_index() } else { None };
         let notifications_muted = self.notifications_muted.if_set_after(updates_since).copied();
         let affected_events = events_reader.affected_event_indexes_since(updates_since, 100);
+        let metrics = if has_new_events { Some(self.events.metrics().clone()) } else { None };
 
         DirectChatSummaryUpdates {
             chat_id: self.them.into(),

--- a/backend/canisters/user/impl/src/model/direct_chat.rs
+++ b/backend/canisters/user/impl/src/model/direct_chat.rs
@@ -91,6 +91,7 @@ impl DirectChat {
             my_metrics: self.events.user_metrics(&my_user_id, None).cloned().unwrap_or_default(),
             archived: self.archived.value,
             events_ttl: self.events.get_events_time_to_live().value,
+            expired_messages: self.events.expired_messages(now),
         }
     }
 
@@ -126,6 +127,7 @@ impl DirectChat {
                 .if_set_after(updates_since)
                 .copied()
                 .map_or(OptionUpdate::NoChange, OptionUpdate::from_update),
+            newly_expired_messages: self.events.expired_messages_since(updates_since, now),
         }
     }
 }

--- a/backend/canisters/user/impl/src/model/direct_chats.rs
+++ b/backend/canisters/user/impl/src/model/direct_chats.rs
@@ -20,10 +20,10 @@ impl DirectChats {
         self.direct_chats.get_mut(chat_id)
     }
 
-    pub fn get_all(&self, updated_since: Option<TimestampMillis>) -> impl Iterator<Item = &DirectChat> {
+    pub fn get_all(&self, updated_since: Option<TimestampMillis>, now: TimestampMillis) -> impl Iterator<Item = &DirectChat> {
         self.direct_chats.values().filter(move |&c| {
             if let Some(updated_since) = updated_since {
-                c.last_updated() > updated_since
+                c.last_updated(now) > updated_since
             } else {
                 true
             }
@@ -51,7 +51,7 @@ impl DirectChats {
 
         let chat: &mut DirectChat = match self.direct_chats.entry(chat_id) {
             Occupied(e) => e.into_mut(),
-            Vacant(e) => e.insert(DirectChat::new(their_user_id, is_bot, args.now)),
+            Vacant(e) => e.insert(DirectChat::new(their_user_id, is_bot, None, args.now)),
         };
 
         let message_event = chat.events.push_message(args);

--- a/backend/canisters/user/impl/src/openchat_bot.rs
+++ b/backend/canisters/user/impl/src/openchat_bot.rs
@@ -130,6 +130,7 @@ pub(crate) fn send_message(content: MessageContent, mute_notification: bool, run
         forwarding: false,
         correlation_id: 0,
         is_bot: true,
+        now: runtime_state.env.now(),
     };
 
     handle_message_impl(OPENCHAT_BOT_USER_ID, args, mute_notification, runtime_state);

--- a/backend/canisters/user/impl/src/queries/deleted_message.rs
+++ b/backend/canisters/user/impl/src/queries/deleted_message.rs
@@ -14,7 +14,8 @@ fn deleted_message_impl(args: Args, state: &RuntimeState) -> Response {
     let my_user_id = state.env.canister_id().into();
 
     if let Some(chat) = state.data.direct_chats.get(&args.user_id.into()) {
-        let events_reader = chat.events.main_events_reader();
+        let now = state.env.now();
+        let events_reader = chat.events.main_events_reader(now);
 
         if let Some(message) = events_reader.message_internal(args.message_id.into()) {
             if my_user_id != message.sender {

--- a/backend/canisters/user/impl/src/queries/events.rs
+++ b/backend/canisters/user/impl/src/queries/events.rs
@@ -11,7 +11,8 @@ fn events(args: Args) -> Response {
 
 fn events_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     if let Some(chat) = runtime_state.data.direct_chats.get(&args.user_id.into()) {
-        let events_reader = chat.events.main_events_reader();
+        let now = runtime_state.env.now();
+        let events_reader = chat.events.main_events_reader(now);
         let latest_event_index = events_reader.latest_event_index().unwrap();
 
         if args.latest_client_event_index.map_or(false, |e| latest_event_index < e) {

--- a/backend/canisters/user/impl/src/queries/events_by_index.rs
+++ b/backend/canisters/user/impl/src/queries/events_by_index.rs
@@ -11,7 +11,8 @@ fn events_by_index(args: Args) -> Response {
 
 fn events_by_index_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     if let Some(chat) = runtime_state.data.direct_chats.get(&args.user_id.into()) {
-        let events_reader = chat.events.main_events_reader();
+        let now = runtime_state.env.now();
+        let events_reader = chat.events.main_events_reader(now);
         let latest_event_index = events_reader.latest_event_index().unwrap();
 
         if args.latest_client_event_index.map_or(false, |e| latest_event_index < e) {

--- a/backend/canisters/user/impl/src/queries/events_window.rs
+++ b/backend/canisters/user/impl/src/queries/events_window.rs
@@ -11,7 +11,8 @@ fn events_window(args: Args) -> Response {
 
 fn events_window_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     if let Some(chat) = runtime_state.data.direct_chats.get(&args.user_id.into()) {
-        let events_reader = chat.events.main_events_reader();
+        let now = runtime_state.env.now();
+        let events_reader = chat.events.main_events_reader(now);
         let latest_event_index = events_reader.latest_event_index().unwrap();
 
         if args.latest_client_event_index.map_or(false, |e| latest_event_index < e) {

--- a/backend/canisters/user/impl/src/queries/initial_state_v2.rs
+++ b/backend/canisters/user/impl/src/queries/initial_state_v2.rs
@@ -109,5 +109,7 @@ fn hydrate_cached_summary(cached: &GroupCanisterGroupChatSummary, user_details: 
         date_last_pinned: cached.date_last_pinned,
         date_read_pinned: user_details.date_read_pinned.value,
         events_ttl: cached.events_ttl,
+        expired_messages: cached.expired_messages.clone(),
+        next_message_expiry: cached.next_message_expiry,
     }
 }

--- a/backend/canisters/user/impl/src/queries/initial_state_v2.rs
+++ b/backend/canisters/user/impl/src/queries/initial_state_v2.rs
@@ -108,5 +108,6 @@ fn hydrate_cached_summary(cached: &GroupCanisterGroupChatSummary, user_details: 
         wasm_version: Version::default(),
         date_last_pinned: cached.date_last_pinned,
         date_read_pinned: user_details.date_read_pinned.value,
+        events_ttl: cached.events_ttl,
     }
 }

--- a/backend/canisters/user/impl/src/queries/initial_state_v2.rs
+++ b/backend/canisters/user/impl/src/queries/initial_state_v2.rs
@@ -23,7 +23,7 @@ fn initial_state_impl(args: Args, runtime_state: &RuntimeState) -> Response {
         .data
         .direct_chats
         .iter()
-        .map(|d| d.to_summary(my_user_id))
+        .map(|d| d.to_summary(my_user_id, now))
         .collect();
 
     let disable_cache = args.disable_cache.unwrap_or_default();

--- a/backend/canisters/user/impl/src/queries/messages_by_message_index.rs
+++ b/backend/canisters/user/impl/src/queries/messages_by_message_index.rs
@@ -12,7 +12,9 @@ fn messages_by_message_index(args: Args) -> Response {
 fn messages_by_message_index_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     if let Some(chat) = runtime_state.data.direct_chats.get(&args.user_id.into()) {
         let my_user_id = runtime_state.env.canister_id().into();
-        let events_reader = chat.events.main_events_reader();
+        let now = runtime_state.env.now();
+
+        let events_reader = chat.events.main_events_reader(now);
         let latest_event_index = events_reader.latest_event_index().unwrap();
 
         let messages: Vec<_> = args

--- a/backend/canisters/user/impl/src/queries/updates_v2.rs
+++ b/backend/canisters/user/impl/src/queries/updates_v2.rs
@@ -16,11 +16,11 @@ fn updates_impl(updates_since: TimestampMillis, runtime_state: &RuntimeState) ->
     let mut direct_chats_added = Vec::new();
     let mut direct_chats_updated = Vec::new();
 
-    for direct_chat in runtime_state.data.direct_chats.get_all(Some(updates_since)) {
+    for direct_chat in runtime_state.data.direct_chats.get_all(Some(updates_since), now) {
         if direct_chat.date_created > updates_since {
-            direct_chats_added.push(direct_chat.to_summary(my_user_id));
+            direct_chats_added.push(direct_chat.to_summary(my_user_id, now));
         } else {
-            direct_chats_updated.push(direct_chat.to_summary_updates(updates_since, my_user_id));
+            direct_chats_updated.push(direct_chat.to_summary_updates(updates_since, my_user_id, now));
         }
     }
 

--- a/backend/canisters/user/impl/src/timer_job_types.rs
+++ b/backend/canisters/user/impl/src/timer_job_types.rs
@@ -87,8 +87,9 @@ impl Job for HardDeleteMessageContentJob {
     fn execute(&self) {
         mutate_state(|state| {
             if let Some(content) = state.data.direct_chats.get_mut(&self.chat_id).and_then(|chat| {
+                let now = state.env.now();
                 chat.events
-                    .remove_deleted_message_content(self.thread_root_message_index, self.message_id)
+                    .remove_deleted_message_content(self.thread_root_message_index, self.message_id, now)
             }) {
                 if self.delete_files {
                     let files_to_delete = content.blob_references();

--- a/backend/canisters/user/impl/src/timer_job_types.rs
+++ b/backend/canisters/user/impl/src/timer_job_types.rs
@@ -2,7 +2,7 @@ use crate::updates::send_message::send_to_recipients_canister;
 use crate::{mutate_state, read_state};
 use canister_timer_jobs::Job;
 use serde::{Deserialize, Serialize};
-use types::{ChatId, MessageContent, MessageId, MessageIndex, UserId};
+use types::{BlobReference, ChatId, MessageContent, MessageId, MessageIndex, UserId};
 use user_canister::c2c_send_messages;
 use user_canister::c2c_send_messages::SendMessageArgs;
 
@@ -11,6 +11,7 @@ pub enum TimerJob {
     RetrySendingFailedMessage(Box<RetrySendingFailedMessageJob>),
     RetrySendingFailedMessages(Box<RetrySendingFailedMessagesJob>),
     HardDeleteMessageContent(Box<HardDeleteMessageContentJob>),
+    DeleteFileReferences(DeleteFileReferencesJob),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -34,12 +35,18 @@ pub struct HardDeleteMessageContentJob {
     pub delete_files: bool,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DeleteFileReferencesJob {
+    pub files: Vec<BlobReference>,
+}
+
 impl Job for TimerJob {
     fn execute(&self) {
         match self {
             TimerJob::RetrySendingFailedMessage(job) => job.execute(),
             TimerJob::RetrySendingFailedMessages(job) => job.execute(),
             TimerJob::HardDeleteMessageContent(job) => job.execute(),
+            TimerJob::DeleteFileReferences(job) => job.execute(),
         }
     }
 }
@@ -94,11 +101,25 @@ impl Job for HardDeleteMessageContentJob {
                 if self.delete_files {
                     let files_to_delete = content.blob_references();
                     if !files_to_delete.is_empty() {
+                        // If there was already a job queued up to delete these files, cancel it
+                        state.data.timer_jobs.cancel_jobs(|job| {
+                            if let TimerJob::DeleteFileReferences(j) = job {
+                                j.files.iter().all(|f| files_to_delete.contains(f))
+                            } else {
+                                false
+                            }
+                        });
                         ic_cdk::spawn(open_storage_bucket_client::delete_files(files_to_delete));
                     }
                 }
             }
         });
+    }
+}
+
+impl Job for DeleteFileReferencesJob {
+    fn execute(&self) {
+        ic_cdk::spawn(open_storage_bucket_client::delete_files(self.files.clone()));
     }
 }
 

--- a/backend/canisters/user/impl/src/updates/c2c_toggle_reaction.rs
+++ b/backend/canisters/user/impl/src/updates/c2c_toggle_reaction.rs
@@ -74,7 +74,7 @@ fn build_notification(
     }
 
     chat.events
-        .main_events_reader()
+        .main_events_reader(now)
         .message_event(message_id.into(), None)
         .filter(|m| m.event.sender != chat.them)
         .map(|message| {

--- a/backend/canisters/user/impl/src/updates/create_group.rs
+++ b/backend/canisters/user/impl/src/updates/create_group.rs
@@ -102,6 +102,7 @@ fn prepare(args: Args, runtime_state: &RuntimeState) -> Result<PrepareResult, Re
             history_visible_to_new_joiners: args.history_visible_to_new_joiners,
             avatar: args.avatar,
             permissions: args.permissions,
+            events_ttl: args.events_ttl,
         };
         Ok(PrepareResult {
             group_index_canister_id: runtime_state.data.group_index_canister_id,

--- a/backend/canisters/user/impl/src/updates/mark_read_v2.rs
+++ b/backend/canisters/user/impl/src/updates/mark_read_v2.rs
@@ -38,7 +38,7 @@ fn mark_read_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
                 if read_up_to
                     <= direct_chat
                         .events
-                        .main_events_reader()
+                        .main_events_reader(now)
                         .latest_message_index()
                         .unwrap_or_default()
                     && direct_chat.mark_read_up_to(read_up_to, true, now)

--- a/backend/canisters/user/impl/src/updates/send_message.rs
+++ b/backend/canisters/user/impl/src/updates/send_message.rs
@@ -169,7 +169,7 @@ fn send_message_impl(
                         .get(&args.recipient.into())
                         .and_then(|chat| {
                             chat.events
-                                .main_events_reader()
+                                .main_events_reader(now)
                                 .message_internal(r.event_index.into())
                                 .map(|m| m.message_id)
                         })

--- a/backend/canisters/user/impl/src/updates/undelete_messages.rs
+++ b/backend/canisters/user/impl/src/updates/undelete_messages.rs
@@ -39,7 +39,7 @@ fn undelete_messages_impl(args: Args, runtime_state: &mut RuntimeState) -> Respo
             .filter_map(|(message_id, result)| matches!(result, UndeleteMessageResult::Success).then_some(message_id))
             .collect();
 
-        let events_reader = chat.events.main_events_reader();
+        let events_reader = chat.events.main_events_reader(now);
 
         let messages: Vec<_> = deleted
             .iter()

--- a/backend/integration_tests/src/client/group.rs
+++ b/backend/integration_tests/src/client/group.rs
@@ -22,6 +22,7 @@ generate_update_call!(remove_reaction);
 generate_update_call!(send_message);
 generate_update_call!(undelete_messages);
 generate_update_call!(unpin_message);
+generate_update_call!(update_group_v2);
 
 pub mod happy_path {
     use crate::rng::random_message_id;

--- a/backend/integration_tests/src/client/group.rs
+++ b/backend/integration_tests/src/client/group.rs
@@ -7,6 +7,8 @@ generate_query_call!(events_by_index);
 generate_query_call!(public_summary);
 generate_query_call!(selected_initial);
 generate_query_call!(selected_updates);
+generate_query_call!(summary);
+generate_query_call!(summary_updates);
 
 // Updates
 generate_update_call!(add_participants);
@@ -28,7 +30,10 @@ pub mod happy_path {
     use crate::rng::random_message_id;
     use crate::User;
     use ic_state_machine_tests::StateMachine;
-    use types::{ChatId, EventIndex, MessageContent, MessageId, MessageIndex, PollVotes, TextContent, UserId, VoteOperation};
+    use types::{
+        ChatId, EventIndex, GroupCanisterGroupChatSummary, GroupCanisterGroupChatSummaryUpdates, MessageContent, MessageId,
+        MessageIndex, PollVotes, TextContent, TimestampMillis, UserId, VoteOperation,
+    };
 
     pub fn add_participants(env: &mut StateMachine, sender: &User, group_chat_id: ChatId, user_ids: Vec<UserId>) {
         let response = super::add_participants(
@@ -125,6 +130,35 @@ pub mod happy_path {
         match response {
             group_canister::events_by_index::Response::Success(result) => result,
             response => panic!("'events_by_index' error: {:?}", response),
+        }
+    }
+
+    pub fn summary(env: &StateMachine, sender: &User, group_chat_id: ChatId) -> GroupCanisterGroupChatSummary {
+        let response = super::summary(env, sender.principal, group_chat_id.into(), &group_canister::summary::Args {});
+
+        match response {
+            group_canister::summary::Response::Success(result) => result.summary,
+            response => panic!("'summary' error: {:?}", response),
+        }
+    }
+
+    pub fn summary_updates(
+        env: &StateMachine,
+        sender: &User,
+        group_chat_id: ChatId,
+        updates_since: TimestampMillis,
+    ) -> Option<GroupCanisterGroupChatSummaryUpdates> {
+        let response = super::summary_updates(
+            env,
+            sender.principal,
+            group_chat_id.into(),
+            &group_canister::summary_updates::Args { updates_since },
+        );
+
+        match response {
+            group_canister::summary_updates::Response::Success(result) => Some(result.updates),
+            group_canister::summary_updates::Response::SuccessNoUpdates => None,
+            response => panic!("'summary_updates' error: {:?}", response),
         }
     }
 }

--- a/backend/integration_tests/src/client/user.rs
+++ b/backend/integration_tests/src/client/user.rs
@@ -79,6 +79,7 @@ pub mod happy_path {
                 permissions: None,
                 rules: GroupRules::default(),
                 subtype: None,
+                events_ttl: None,
             },
         );
 

--- a/backend/integration_tests/src/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/disappearing_message_tests.rs
@@ -35,6 +35,7 @@ fn disappearing_messages_in_group_chats() {
     );
 
     env.advance_time(Duration::from_millis(2000));
+    env.tick();
 
     assert!(
         client::group::happy_path::events_by_index(&env, &user1, group_id, vec![send_message_response1.event_index])
@@ -56,6 +57,7 @@ fn disappearing_messages_in_group_chats() {
     let send_message_response2 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "xyz", None);
 
     env.advance_time(Duration::from_secs(100000));
+    env.tick();
 
     assert!(
         client::group::happy_path::events_by_index(&env, &user1, group_id, vec![send_message_response2.event_index])

--- a/backend/integration_tests/src/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/disappearing_message_tests.rs
@@ -1,0 +1,88 @@
+use crate::rng::random_string;
+use crate::setup::{return_env, setup_env, TestEnv};
+use crate::{client, User};
+use ic_state_machine_tests::StateMachine;
+use std::time::Duration;
+use types::{CanisterId, ChatId, OptionUpdate};
+
+#[test]
+fn disappearing_messages_in_group_chats() {
+    let TestEnv {
+        mut env,
+        canister_ids,
+        controller,
+    } = setup_env();
+
+    let TestData { user1, group_id } = init_test_data(&mut env, canister_ids.user_index, true);
+
+    client::group::update_group_v2(
+        &mut env,
+        user1.principal,
+        group_id.into(),
+        &group_canister::update_group_v2::Args {
+            events_ttl: OptionUpdate::SetToSome(1000),
+            ..Default::default()
+        },
+    );
+
+    let send_message_response1 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "abc", None);
+
+    assert!(
+        client::group::happy_path::events_by_index(&env, &user1, group_id, vec![send_message_response1.event_index])
+            .events
+            .first()
+            .is_some()
+    );
+
+    env.advance_time(Duration::from_millis(2000));
+
+    assert!(
+        client::group::happy_path::events_by_index(&env, &user1, group_id, vec![send_message_response1.event_index])
+            .events
+            .first()
+            .is_none()
+    );
+
+    client::group::update_group_v2(
+        &mut env,
+        user1.principal,
+        group_id.into(),
+        &group_canister::update_group_v2::Args {
+            events_ttl: OptionUpdate::SetToNone,
+            ..Default::default()
+        },
+    );
+
+    let send_message_response2 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "xyz", None);
+
+    env.advance_time(Duration::from_secs(100000));
+
+    assert!(
+        client::group::happy_path::events_by_index(&env, &user1, group_id, vec![send_message_response2.event_index])
+            .events
+            .first()
+            .is_some()
+    );
+
+    return_env(TestEnv {
+        env,
+        canister_ids,
+        controller,
+    });
+}
+
+fn init_test_data(env: &mut StateMachine, user_index: CanisterId, public: bool) -> TestData {
+    let user1 = client::user_index::happy_path::register_user(env, user_index);
+
+    let group_name = random_string();
+
+    let group_id = client::user::happy_path::create_group(env, &user1, &group_name, public, true);
+
+    TestData { user1, group_id }
+}
+
+#[allow(dead_code)]
+struct TestData {
+    user1: User,
+    group_id: ChatId,
+}

--- a/backend/integration_tests/src/disappearing_message_tests.rs
+++ b/backend/integration_tests/src/disappearing_message_tests.rs
@@ -2,6 +2,7 @@ use crate::rng::random_string;
 use crate::setup::{return_env, setup_env, TestEnv};
 use crate::{client, User};
 use ic_state_machine_tests::StateMachine;
+use itertools::Itertools;
 use std::time::Duration;
 use types::{CanisterId, ChatId, OptionUpdate};
 
@@ -64,6 +65,87 @@ fn disappearing_messages_in_group_chats() {
             .events
             .first()
             .is_some()
+    );
+
+    return_env(TestEnv {
+        env,
+        canister_ids,
+        controller,
+    });
+}
+
+#[test]
+fn group_chat_summary_contains_expired_messages() {
+    let TestEnv {
+        mut env,
+        canister_ids,
+        controller,
+    } = setup_env();
+
+    let TestData { user1, group_id } = init_test_data(&mut env, canister_ids.user_index, true);
+
+    client::group::update_group_v2(
+        &mut env,
+        user1.principal,
+        group_id.into(),
+        &group_canister::update_group_v2::Args {
+            events_ttl: OptionUpdate::SetToSome(1000),
+            ..Default::default()
+        },
+    );
+
+    let send_message_response1 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "abc", None);
+    env.advance_time(Duration::from_millis(400));
+    let send_message_response2 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "def", None);
+    env.advance_time(Duration::from_millis(400));
+    let send_message_response3 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "ghi", None);
+    env.advance_time(Duration::from_millis(400));
+    let send_message_response4 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "jkl", None);
+    env.advance_time(Duration::from_millis(400));
+    let send_message_response5 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "mno", None);
+    env.advance_time(Duration::from_millis(400));
+    let send_message_response6 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "mno", None);
+
+    let summary = client::group::happy_path::summary(&env, &user1, group_id);
+    let summary_timestamp = send_message_response6.timestamp;
+
+    assert_eq!(summary.events_ttl, Some(1000));
+    assert_eq!(
+        summary.expired_messages.iter().collect_vec(),
+        vec![
+            send_message_response1.message_index,
+            send_message_response2.message_index,
+            send_message_response3.message_index
+        ]
+    );
+    assert_eq!(summary.next_message_expiry, send_message_response4.expires_at);
+
+    env.advance_time(Duration::from_millis(2000));
+
+    client::group::update_group_v2(
+        &mut env,
+        user1.principal,
+        group_id.into(),
+        &group_canister::update_group_v2::Args {
+            events_ttl: OptionUpdate::SetToSome(2000),
+            ..Default::default()
+        },
+    );
+    let send_message_response7 = client::group::happy_path::send_text_message(&mut env, &user1, group_id, "pqr", None);
+    let summary_updates = client::group::happy_path::summary_updates(&env, &user1, group_id, summary_timestamp).unwrap();
+
+    assert_eq!(summary_updates.events_ttl.expand(), Some(Some(2000)));
+    assert_eq!(
+        summary_updates.newly_expired_messages.iter().collect_vec(),
+        vec![
+            send_message_response4.message_index,
+            send_message_response5.message_index,
+            send_message_response6.message_index
+        ]
+    );
+    assert_eq!(
+        summary_updates.next_message_expiry.expand(),
+        Some(send_message_response7.expires_at)
     );
 
     return_env(TestEnv {

--- a/backend/integration_tests/src/lib.rs
+++ b/backend/integration_tests/src/lib.rs
@@ -7,6 +7,7 @@ use types::{CanisterId, UserId};
 mod client;
 mod delete_group_tests;
 mod delete_message_tests;
+mod disappearing_message_tests;
 mod freeze_group_tests;
 mod join_group_tests;
 mod last_online_date_tests;

--- a/backend/libraries/chat_events/src/chat_event_internal.rs
+++ b/backend/libraries/chat_events/src/chat_event_internal.rs
@@ -4,12 +4,13 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 use types::{
-    AvatarChanged, ChatFrozen, ChatMetrics, ChatUnfrozen, Cryptocurrency, DeletedBy, DirectChatCreated, GroupChatCreated,
-    GroupDescriptionChanged, GroupInviteCodeChanged, GroupNameChanged, GroupRulesChanged, GroupVisibilityChanged, Message,
-    MessageContent, MessageContentInternal, MessageId, MessageIndex, MessagePinned, MessageUnpinned, OwnershipTransferred,
-    ParticipantAssumesSuperAdmin, ParticipantDismissedAsSuperAdmin, ParticipantJoined, ParticipantLeft,
-    ParticipantRelinquishesSuperAdmin, ParticipantsAdded, ParticipantsRemoved, PermissionsChanged, PollVoteRegistered,
-    Reaction, ReplyContext, RoleChanged, ThreadSummary, TimestampMillis, UserId, UsersBlocked, UsersUnblocked,
+    AvatarChanged, ChatFrozen, ChatMetrics, ChatUnfrozen, Cryptocurrency, DeletedBy, DirectChatCreated,
+    EventsTimeToLiveUpdated, GroupChatCreated, GroupDescriptionChanged, GroupInviteCodeChanged, GroupNameChanged,
+    GroupRulesChanged, GroupVisibilityChanged, Message, MessageContent, MessageContentInternal, MessageId, MessageIndex,
+    MessagePinned, MessageUnpinned, OwnershipTransferred, ParticipantAssumesSuperAdmin, ParticipantDismissedAsSuperAdmin,
+    ParticipantJoined, ParticipantLeft, ParticipantRelinquishesSuperAdmin, ParticipantsAdded, ParticipantsRemoved,
+    PermissionsChanged, PollVoteRegistered, Reaction, ReplyContext, RoleChanged, ThreadSummary, TimestampMillis, UserId,
+    UsersBlocked, UsersUnblocked,
 };
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -49,6 +50,7 @@ pub enum ChatEventInternal {
     ProposalsUpdated(Box<ProposalsUpdatedInternal>),
     ChatFrozen(Box<ChatFrozen>),
     ChatUnfrozen(Box<ChatUnfrozen>),
+    EventsTimeToLiveUpdated(Box<EventsTimeToLiveUpdated>),
 }
 
 impl ChatEventInternal {
@@ -66,6 +68,7 @@ impl ChatEventInternal {
                 | ChatEventInternal::PollVoteDeleted(_)
                 | ChatEventInternal::PollEnded(_)
                 | ChatEventInternal::ThreadUpdated(_)
+                | ChatEventInternal::EventsTimeToLiveUpdated(_)
         )
     }
 
@@ -106,6 +109,7 @@ impl ChatEventInternal {
                 | ChatEventInternal::ProposalsUpdated(_)
                 | ChatEventInternal::ChatFrozen(_)
                 | ChatEventInternal::ChatUnfrozen(_)
+                | ChatEventInternal::EventsTimeToLiveUpdated(_)
         )
     }
 
@@ -227,6 +231,7 @@ impl ChatEventInternal {
             ChatEventInternal::GroupInviteCodeChanged(p) => Some(p.changed_by),
             ChatEventInternal::ChatFrozen(f) => Some(f.frozen_by),
             ChatEventInternal::ChatUnfrozen(u) => Some(u.unfrozen_by),
+            ChatEventInternal::EventsTimeToLiveUpdated(u) => Some(u.updated_by),
             ChatEventInternal::MessageEdited(e)
             | ChatEventInternal::MessageDeleted(e)
             | ChatEventInternal::MessageUndeleted(e)

--- a/backend/libraries/chat_events/src/chat_events.rs
+++ b/backend/libraries/chat_events/src/chat_events.rs
@@ -1,16 +1,17 @@
 use crate::*;
 use ::types::{
-    ChatFrozen, ChatId, ChatMetrics, ChatUnfrozen, DeletedBy, DirectChatCreated, EventIndex, EventWrapper,
-    GroupCanisterThreadDetails, GroupChatCreated, Mention, MentionInternal, Message, MessageContent, MessageContentInternal,
-    MessageId, MessageIndex, MessageMatch, Milliseconds, PollVoteRegistered, PollVotes, ProposalStatusUpdate, PushEventResult,
-    Reaction, RegisterVoteResult, ReplyContext, TimestampMillis, UserId, VoteOperation,
+    BlobReference, ChatFrozen, ChatId, ChatMetrics, ChatUnfrozen, DeletedBy, DirectChatCreated, EventIndex, EventWrapper,
+    EventsTimeToLiveUpdated, GroupCanisterThreadDetails, GroupChatCreated, Mention, MentionInternal, Message, MessageContent,
+    MessageContentInternal, MessageId, MessageIndex, MessageMatch, Milliseconds, PollVoteRegistered, PollVotes,
+    ProposalStatusUpdate, PushEventResult, PushIfNotContains, Reaction, RegisterVoteResult, ReplyContext, ThreadSummary,
+    TimestampMillis, UserId, VoteOperation,
 };
 use itertools::Itertools;
 use search::{Document, Query};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BinaryHeap, HashMap};
 
 #[derive(Serialize, Deserialize)]
 #[serde(from = "ChatEventsOld")]
@@ -22,7 +23,9 @@ pub struct ChatEvents {
     metrics: ChatMetrics,
     per_user_metrics: HashMap<UserId, ChatMetrics>,
     frozen: bool,
-    events_expire_after: Option<Milliseconds>,
+    events_ttl: Option<Milliseconds>,
+    event_expiry_dates: BinaryHeap<EventExpiryDate>,
+    files_to_delete: BTreeMap<TimestampMillis, Vec<BlobReference>>,
 }
 
 #[derive(Deserialize)]
@@ -50,13 +53,15 @@ impl From<ChatEventsOld> for ChatEvents {
             metrics: value.metrics,
             per_user_metrics: value.per_user_metrics,
             frozen: value.frozen,
-            events_expire_after: None,
+            events_ttl: None,
+            event_expiry_dates: BinaryHeap::new(),
+            files_to_delete: BTreeMap::new(),
         }
     }
 }
 
 impl ChatEvents {
-    pub fn new_direct_chat(them: UserId, now: TimestampMillis) -> ChatEvents {
+    pub fn new_direct_chat(them: UserId, events_ttl: Option<Milliseconds>, now: TimestampMillis) -> ChatEvents {
         let mut events = ChatEvents {
             chat_id: them.into(),
             chat_type: ChatType::Direct,
@@ -65,7 +70,9 @@ impl ChatEvents {
             metrics: ChatMetrics::default(),
             per_user_metrics: HashMap::new(),
             frozen: false,
-            events_expire_after: None,
+            events_ttl,
+            event_expiry_dates: BinaryHeap::new(),
+            files_to_delete: BTreeMap::new(),
         };
 
         events.push_event(None, ChatEventInternal::DirectChatCreated(DirectChatCreated {}), 0, now);
@@ -78,6 +85,7 @@ impl ChatEvents {
         name: String,
         description: String,
         created_by: UserId,
+        events_ttl: Option<Milliseconds>,
         now: TimestampMillis,
     ) -> ChatEvents {
         let mut events = ChatEvents {
@@ -88,7 +96,9 @@ impl ChatEvents {
             metrics: ChatMetrics::default(),
             per_user_metrics: HashMap::new(),
             frozen: false,
-            events_expire_after: None,
+            events_ttl,
+            event_expiry_dates: BinaryHeap::new(),
+            files_to_delete: BTreeMap::new(),
         };
 
         events.push_event(
@@ -136,13 +146,12 @@ impl ChatEvents {
         );
 
         if let Some(root_message_index) = args.thread_root_message_index {
-            self.main.update_thread_summary(
+            self.update_thread_summary(
                 root_message_index,
                 args.sender,
                 Some(message_index),
                 push_event_result.index,
                 args.correlation_id,
-                push_event_result.expires_at,
                 args.now,
             );
         }
@@ -161,6 +170,7 @@ impl ChatEvents {
             args.min_visible_event_index,
             args.thread_root_message_index,
             args.message_id.into(),
+            args.now,
         ) {
             if message.sender == args.sender {
                 if !matches!(message.content, MessageContentInternal::Deleted(_)) {
@@ -178,13 +188,12 @@ impl ChatEvents {
                     );
 
                     if let Some(root_message_index) = args.thread_root_message_index {
-                        self.main.update_thread_summary(
+                        self.update_thread_summary(
                             root_message_index,
                             args.sender,
                             None,
                             push_event_result.index,
                             args.correlation_id,
-                            self.expiry_date(false, args.now),
                             args.now,
                         );
                     }
@@ -200,49 +209,46 @@ impl ChatEvents {
     }
 
     pub fn delete_messages(&mut self, args: DeleteUndeleteMessagesArgs) -> Vec<(MessageId, DeleteMessageResult)> {
-        let results = args
+        let results: Vec<_> = args
             .iter()
             .map(|delete_message_args| (delete_message_args.message_id, self.delete_message(delete_message_args)))
             .collect();
 
-        if let Some(root_message_index) = args.thread_root_message_index {
-            if let Some(thread_events) = self.threads.get(&root_message_index) {
-                self.main.update_thread_summary(
-                    root_message_index,
-                    args.caller,
-                    None,
-                    thread_events.last().index,
-                    args.correlation_id,
-                    self.expiry_date(false, args.now),
-                    args.now,
-                );
-            }
+        if results.iter().any(|(_, r)| matches!(r, DeleteMessageResult::Success)) {
+            self.update_thread_summary_after_successful_delete_undelete(args);
         }
 
         results
     }
 
     pub fn undelete_messages(&mut self, args: DeleteUndeleteMessagesArgs) -> Vec<(MessageId, UndeleteMessageResult)> {
-        let results = args
+        let results: Vec<_> = args
             .iter()
             .map(|undelete_message_args| (undelete_message_args.message_id, self.undelete_message(undelete_message_args)))
             .collect();
 
-        if let Some(root_message_index) = args.thread_root_message_index {
-            if let Some(thread_events) = self.threads.get(&root_message_index) {
-                self.main.update_thread_summary(
-                    root_message_index,
-                    args.caller,
-                    None,
-                    thread_events.last().index,
-                    args.correlation_id,
-                    self.expiry_date(false, args.now),
-                    args.now,
-                );
-            }
+        if results.iter().any(|(_, r)| matches!(r, UndeleteMessageResult::Success)) {
+            self.update_thread_summary_after_successful_delete_undelete(args);
         }
 
         results
+    }
+
+    fn update_thread_summary_after_successful_delete_undelete(&mut self, args: DeleteUndeleteMessagesArgs) {
+        if let Some(root_message_index) = args.thread_root_message_index {
+            if let Some(thread_events) = self.threads.get(&root_message_index) {
+                if let Some(latest_event_index) = thread_events.latest_event_index() {
+                    self.update_thread_summary(
+                        root_message_index,
+                        args.caller,
+                        None,
+                        latest_event_index,
+                        args.correlation_id,
+                        args.now,
+                    );
+                }
+            }
+        }
     }
 
     fn delete_message(&mut self, args: DeleteUndeleteMessageArgs) -> DeleteMessageResult {
@@ -250,6 +256,7 @@ impl ChatEvents {
             args.min_visible_event_index,
             args.thread_root_message_index,
             args.message_id.into(),
+            args.now,
         ) {
             if message.sender == args.caller || args.is_admin {
                 if message.deleted_by.is_some() {
@@ -291,6 +298,7 @@ impl ChatEvents {
             args.min_visible_event_index,
             args.thread_root_message_index,
             args.message_id.into(),
+            args.now,
         ) {
             if let Some(deleted_by) = message.deleted_by.as_ref().map(|db| db.deleted_by) {
                 if deleted_by == args.caller || (args.is_admin && message.sender != deleted_by) {
@@ -329,8 +337,9 @@ impl ChatEvents {
         &mut self,
         thread_root_message_index: Option<MessageIndex>,
         message_id: MessageId,
+        now: TimestampMillis,
     ) -> Option<MessageContentInternal> {
-        let message = self.message_internal_mut(EventIndex::default(), thread_root_message_index, message_id.into())?;
+        let message = self.message_internal_mut(EventIndex::default(), thread_root_message_index, message_id.into(), now)?;
         let deleted_by = message.deleted_by.clone()?;
 
         Some(std::mem::replace(
@@ -344,6 +353,7 @@ impl ChatEvents {
             args.min_visible_event_index,
             args.thread_root_message_index,
             args.message_index.into(),
+            args.now,
         ) {
             if let MessageContentInternal::Poll(p) = &mut message.content {
                 return match p.register_vote(args.user_id, args.option_index, args.operation) {
@@ -367,13 +377,12 @@ impl ChatEvents {
                             self.push_event(args.thread_root_message_index, event, args.correlation_id, args.now);
 
                         if let Some(root_message_index) = args.thread_root_message_index {
-                            self.main.update_thread_summary(
+                            self.update_thread_summary(
                                 root_message_index,
                                 args.user_id,
                                 None,
                                 push_event_result.index,
                                 args.correlation_id,
-                                self.expiry_date(false, args.now),
                                 args.now,
                             );
                         }
@@ -399,7 +408,8 @@ impl ChatEvents {
         correlation_id: u64,
         now: TimestampMillis,
     ) -> EndPollResult {
-        if let Some(message) = self.message_internal_mut(EventIndex::default(), thread_root_message_index, message_index.into())
+        if let Some(message) =
+            self.message_internal_mut(EventIndex::default(), thread_root_message_index, message_index.into(), now)
         {
             if let MessageContentInternal::Poll(p) = &mut message.content {
                 return if p.ended || p.config.end_date.is_none() {
@@ -423,9 +433,10 @@ impl ChatEvents {
         min_visible_event_index: EventIndex,
         message_index: MessageIndex,
         adopt: bool,
+        now: TimestampMillis,
     ) -> RecordProposalVoteResult {
         if let Some(proposal) = self
-            .message_internal_mut(min_visible_event_index, None, message_index.into())
+            .message_internal_mut(min_visible_event_index, None, message_index.into(), now)
             .and_then(
                 |m| {
                     if let MessageContentInternal::GovernanceProposal(p) = &mut m.content {
@@ -463,7 +474,7 @@ impl ChatEvents {
         for (message_id, update) in updates {
             if let Some(message) = self
                 .main
-                .get_mut(message_id.into(), EventIndex::default())
+                .get_mut(message_id.into(), EventIndex::default(), now)
                 .and_then(|e| e.event.as_message_mut())
                 .filter(|m| m.sender == user_id)
             {
@@ -477,11 +488,12 @@ impl ChatEvents {
             message_indexes.sort_unstable();
 
             let mut push_new_event = true;
-            let mut last_event = self.main.last_mut();
-            if let ChatEventInternal::ProposalsUpdated(p) = &last_event.event {
-                if p.proposals == message_indexes {
-                    last_event.timestamp = now;
-                    push_new_event = false;
+            if let Some(last_event) = self.main.last_mut() {
+                if let ChatEventInternal::ProposalsUpdated(p) = &last_event.event {
+                    if p.proposals == message_indexes {
+                        last_event.timestamp = now;
+                        push_new_event = false;
+                    }
                 }
             }
 
@@ -512,6 +524,7 @@ impl ChatEvents {
             args.min_visible_event_index,
             args.thread_root_message_index,
             args.message_id.into(),
+            args.now,
         ) {
             let added = if let Some((_, users)) = message.reactions.iter_mut().find(|(r, _)| *r == args.reaction) {
                 users.insert(args.user_id)
@@ -539,13 +552,12 @@ impl ChatEvents {
             );
 
             if let Some(root_message_index) = args.thread_root_message_index {
-                self.main.update_thread_summary(
+                self.update_thread_summary(
                     root_message_index,
                     args.user_id,
                     None,
                     push_event_result.index,
                     args.correlation_id,
-                    self.expiry_date(false, args.now),
                     args.now,
                 );
             }
@@ -561,6 +573,7 @@ impl ChatEvents {
             args.min_visible_event_index,
             args.thread_root_message_index,
             args.message_id.into(),
+            args.now,
         ) {
             let (removed, is_empty) = message
                 .reactions
@@ -590,13 +603,12 @@ impl ChatEvents {
             );
 
             if let Some(root_message_index) = args.thread_root_message_index {
-                self.main.update_thread_summary(
+                self.update_thread_summary(
                     root_message_index,
                     args.user_id,
                     None,
                     push_event_result.index,
                     args.correlation_id,
-                    self.expiry_date(false, args.now),
                     args.now,
                 );
             }
@@ -604,6 +616,58 @@ impl ChatEvents {
             AddRemoveReactionResult::Success(push_event_result)
         } else {
             AddRemoveReactionResult::MessageNotFound
+        }
+    }
+
+    fn update_thread_summary(
+        &mut self,
+        thread_root_message_index: MessageIndex,
+        user_id: UserId,
+        latest_thread_message_index_if_updated: Option<MessageIndex>,
+        latest_event_index: EventIndex,
+        correlation_id: u64,
+        now: TimestampMillis,
+    ) {
+        // If the current latest event is a `ThreadUpdated` event for the same thread then update
+        // that existing event, else push a new event.
+        let mut push_new_event = true;
+        if let Some(latest_event) = self.main.last_mut() {
+            if let ChatEventInternal::ThreadUpdated(u) = &mut latest_event.event {
+                if u.message_index == thread_root_message_index {
+                    latest_event.timestamp = now;
+                    if let Some(latest_message_index) = latest_thread_message_index_if_updated {
+                        u.latest_thread_message_index_if_updated = Some(latest_message_index);
+                    }
+                    push_new_event = false;
+                }
+            }
+        }
+
+        if push_new_event {
+            self.push_event(
+                None,
+                ChatEventInternal::ThreadUpdated(Box::new(ThreadUpdatedInternal {
+                    message_index: thread_root_message_index,
+                    latest_thread_message_index_if_updated,
+                })),
+                correlation_id,
+                now,
+            );
+        }
+
+        let root_message = self
+            .message_internal_mut(EventIndex::default(), None, thread_root_message_index.into(), now)
+            .unwrap_or_else(|| panic!("Root thread message not found with message index {thread_root_message_index:?}"));
+
+        root_message.last_updated = Some(now);
+
+        let mut summary = root_message.thread_summary.get_or_insert_with(ThreadSummary::default);
+        summary.latest_event_index = latest_event_index;
+        summary.latest_event_timestamp = now;
+
+        if latest_thread_message_index_if_updated.is_some() {
+            summary.reply_count += 1;
+            summary.participant_ids.push_if_not_contains(user_id);
         }
     }
 
@@ -634,7 +698,7 @@ impl ChatEvents {
             panic!("Event type is not valid: {event:?}");
         }
 
-        let expires_at = self.expiry_date(thread_root_message_index.is_some(), now);
+        let expires_at = self.expiry_date(&event, thread_root_message_index.is_some(), now);
 
         let events_list = if let Some(root_message_index) = thread_root_message_index {
             self.threads.get_mut(&root_message_index).unwrap()
@@ -644,7 +708,7 @@ impl ChatEvents {
 
         let deleted_message_sender = match &event {
             ChatEventInternal::MessageDeleted(m) | ChatEventInternal::MessageUndeleted(m) => {
-                ChatEventsListReader::new(events_list)
+                ChatEventsListReader::new(events_list, now)
                     .message_internal(m.message_id.into())
                     .map(|m| m.sender)
             }
@@ -653,12 +717,36 @@ impl ChatEvents {
 
         event.add_to_metrics(&mut self.metrics, &mut self.per_user_metrics, deleted_message_sender, now);
 
-        let index = events_list.push_event(event, correlation_id, expires_at, now);
+        let event_index = events_list.push_event(event, correlation_id, expires_at, now);
+
+        if let Some(timestamp) = expires_at {
+            self.event_expiry_dates.push(EventExpiryDate { timestamp, event_index })
+        }
+
+        self.remove_expired_events(now);
 
         PushEventResult {
-            index,
+            index: event_index,
             timestamp: now,
             expires_at,
+        }
+    }
+
+    pub fn get_events_time_to_live(&self) -> Option<Milliseconds> {
+        self.events_ttl
+    }
+
+    pub fn set_events_time_to_live(&mut self, user_id: UserId, events_ttl: Option<Milliseconds>, now: TimestampMillis) {
+        if events_ttl != self.events_ttl {
+            self.events_ttl = events_ttl;
+            self.push_main_event(
+                ChatEventInternal::EventsTimeToLiveUpdated(Box::new(EventsTimeToLiveUpdated {
+                    updated_by: user_id,
+                    new_ttl: events_ttl,
+                })),
+                0,
+                now,
+            );
         }
     }
 
@@ -670,8 +758,8 @@ impl ChatEvents {
         max_results: u8,
         my_user_id: UserId,
     ) -> Vec<MessageMatch> {
-        self.main
-            .iter(None, true, min_visible_event_index)
+        self.visible_main_events_reader(min_visible_event_index, now)
+            .iter(None, true)
             .filter_map(|e| e.event.as_message().filter(|m| m.deleted_by.is_none()).map(|m| (e, m)))
             .filter(|(_, m)| if query.users.is_empty() { true } else { query.users.contains(&m.sender) })
             .filter_map(|(e, m)| {
@@ -703,8 +791,13 @@ impl ChatEvents {
         self.push_event(None, event, correlation_id, now)
     }
 
-    pub fn hydrate_mention(&self, min_visible_event_index: EventIndex, mention: &MentionInternal) -> Option<Mention> {
-        let events_reader = self.events_reader(min_visible_event_index, mention.thread_root_message_index)?;
+    pub fn hydrate_mention(
+        &self,
+        min_visible_event_index: EventIndex,
+        mention: &MentionInternal,
+        now: TimestampMillis,
+    ) -> Option<Mention> {
+        let events_reader = self.events_reader(min_visible_event_index, mention.thread_root_message_index, now)?;
         events_reader.hydrate_mention(mention)
     }
 
@@ -718,12 +811,17 @@ impl ChatEvents {
             .filter(|m| if let Some(since) = if_updated_since { m.last_active > since } else { true })
     }
 
-    pub fn event_count_since<F: Fn(&ChatEventInternal) -> bool>(&self, since: TimestampMillis, filter: F) -> usize {
-        self.main.event_count_since(since, &filter)
+    pub fn event_count_since<F: Fn(&ChatEventInternal) -> bool>(
+        &self,
+        since: TimestampMillis,
+        now: TimestampMillis,
+        filter: F,
+    ) -> usize {
+        self.main.event_count_since(since, now, &filter)
             + self
                 .threads
                 .values()
-                .map(|e| e.event_count_since(since, &filter))
+                .map(|e| e.event_count_since(since, now, &filter))
                 .sum::<usize>()
     }
 
@@ -732,26 +830,12 @@ impl ChatEvents {
         min_visible_event_index: EventIndex,
         thread_root_message_index: Option<MessageIndex>,
         event_key: EventKey,
+        now: TimestampMillis,
     ) -> bool {
-        if let Some(events_list) = self.events_list(min_visible_event_index, thread_root_message_index) {
-            events_list.is_accessible(event_key, min_visible_event_index)
+        if let Some(events_list) = self.events_reader(min_visible_event_index, thread_root_message_index, now) {
+            events_list.is_accessible(event_key, min_visible_event_index, now)
         } else {
             false
-        }
-    }
-
-    pub fn are_messages_accessible(
-        &self,
-        min_visible_event_index: EventIndex,
-        thread_root_message_index: Option<MessageIndex>,
-        event_keys: Vec<EventKey>,
-    ) -> bool {
-        if let Some(root_message_index) = thread_root_message_index {
-            self.main.is_accessible(root_message_index.into(), min_visible_event_index)
-        } else {
-            event_keys
-                .iter()
-                .all(|k| self.main.is_accessible(*k, min_visible_event_index))
         }
     }
 
@@ -761,19 +845,24 @@ impl ChatEvents {
         root_message_indexes: impl Iterator<Item = &'a MessageIndex>,
         updated_since: Option<TimestampMillis>,
         max_threads: usize,
+        now: TimestampMillis,
     ) -> Vec<GroupCanisterThreadDetails> {
         root_message_indexes
-            .filter(|&&root_message_index| self.main.is_accessible(root_message_index.into(), min_visible_event_index))
+            .filter(|&&root_message_index| {
+                self.main
+                    .is_accessible(root_message_index.into(), min_visible_event_index, now)
+            })
             .filter_map(|root_message_index| {
                 self.threads.get(root_message_index).and_then(|thread_events| {
-                    let latest_event = thread_events.last();
+                    let last_updated = thread_events.latest_event_timestamp()?;
+                    let latest_event = thread_events.latest_event_index()?;
                     updated_since
-                        .map_or(true, |since| latest_event.timestamp > since)
+                        .map_or(true, |since| last_updated > since)
                         .then_some(GroupCanisterThreadDetails {
                             root_message_index: *root_message_index,
-                            latest_event: latest_event.index,
+                            latest_event,
                             latest_message: thread_events.latest_message_index().unwrap_or_default(),
-                            last_updated: latest_event.timestamp,
+                            last_updated,
                         })
                 })
             })
@@ -806,27 +895,53 @@ impl ChatEvents {
         )
     }
 
-    pub fn main_events_reader(&self) -> ChatEventsListReader {
-        ChatEventsListReader::new(&self.main)
+    pub fn remove_expired_events(&mut self, now: TimestampMillis) {
+        while let Some(next) = self
+            .event_expiry_dates
+            .peek()
+            .map_or(false, |e| e.timestamp < now)
+            .then(|| self.event_expiry_dates.pop().unwrap())
+        {
+            if let Some(event) = self.main.remove_expired_event(next.event_index) {
+                if let ChatEventInternal::Message(m) = event.event {
+                    self.threads.remove(&m.message_index);
+
+                    let files_to_delete = m.content.blob_references();
+                    if !files_to_delete.is_empty() {
+                        self.files_to_delete.insert(now, files_to_delete);
+                    }
+                }
+            }
+        }
     }
 
-    pub fn visible_main_events_reader(&self, min_visible_event_index: EventIndex) -> ChatEventsListReader {
-        ChatEventsListReader::with_min_visible_event_index(&self.main, min_visible_event_index)
+    pub fn main_events_reader(&self, now: TimestampMillis) -> ChatEventsListReader {
+        ChatEventsListReader::new(&self.main, now)
+    }
+
+    pub fn visible_main_events_reader(
+        &self,
+        min_visible_event_index: EventIndex,
+        now: TimestampMillis,
+    ) -> ChatEventsListReader {
+        ChatEventsListReader::with_min_visible_event_index(&self.main, min_visible_event_index, now)
     }
 
     pub fn events_reader(
         &self,
         min_visible_event_index: EventIndex,
         thread_root_message_index: Option<MessageIndex>,
+        now: TimestampMillis,
     ) -> Option<ChatEventsListReader> {
-        let events_list = self.events_list(min_visible_event_index, thread_root_message_index)?;
+        let events_list = self.events_list(min_visible_event_index, thread_root_message_index, now)?;
 
         if thread_root_message_index.is_some() {
-            Some(ChatEventsListReader::new(events_list))
+            Some(ChatEventsListReader::new(events_list, now))
         } else {
             Some(ChatEventsListReader::with_min_visible_event_index(
                 events_list,
                 min_visible_event_index,
+                now,
             ))
         }
     }
@@ -835,11 +950,12 @@ impl ChatEvents {
         &self,
         min_visible_event_index: EventIndex,
         thread_root_message_index: Option<MessageIndex>,
+        now: TimestampMillis,
     ) -> Option<&ChatEventsList> {
         if let Some(root_message_index) = thread_root_message_index {
             if self
                 .main
-                .is_accessible(EventKey::MessageIndex(root_message_index), min_visible_event_index)
+                .is_accessible(root_message_index.into(), min_visible_event_index, now)
             {
                 self.threads.get(&root_message_index)
             } else {
@@ -854,11 +970,12 @@ impl ChatEvents {
         &mut self,
         min_visible_event_index: EventIndex,
         thread_root_message_index: Option<MessageIndex>,
+        now: TimestampMillis,
     ) -> Option<&mut ChatEventsList> {
         if let Some(root_message_index) = thread_root_message_index {
             if self
                 .main
-                .is_accessible(EventKey::MessageIndex(root_message_index), min_visible_event_index)
+                .is_accessible(root_message_index.into(), min_visible_event_index, now)
             {
                 self.threads.get_mut(&root_message_index)
             } else {
@@ -874,19 +991,44 @@ impl ChatEvents {
         min_visible_event_index: EventIndex,
         thread_root_message_index: Option<MessageIndex>,
         event_key: EventKey,
+        now: TimestampMillis,
     ) -> Option<&mut MessageInternal> {
-        let events_list = self.events_list_mut(min_visible_event_index, thread_root_message_index)?;
+        let events_list = self.events_list_mut(min_visible_event_index, thread_root_message_index, now)?;
 
         events_list
-            .get_mut(event_key, min_visible_event_index)
+            .get_mut(event_key, min_visible_event_index, now)
             .and_then(|e| e.event.as_message_mut())
     }
 
-    fn expiry_date(&self, is_thread_event: bool, now: TimestampMillis) -> Option<TimestampMillis> {
+    fn expiry_date(&self, event: &ChatEventInternal, is_thread_event: bool, now: TimestampMillis) -> Option<TimestampMillis> {
         if is_thread_event {
             None
         } else {
-            self.events_expire_after.map(|d| now + d)
+            let events_reader = self.main_events_reader(now);
+            let affected_events: Vec<_> = events_reader
+                .affected_event_indexes(event)
+                .into_iter()
+                .filter_map(|e| events_reader.get(e.into()))
+                .collect();
+
+            if affected_events.is_empty() {
+                self.events_ttl.map(|d| now + d)
+            } else {
+                // If this event affects existing events, then this event cannot expire until all of
+                // the events it affects have first expired. So we need to find the max expiry date
+                // of the affected events.
+                let mut max_expiry = now;
+                for e in affected_events {
+                    if let Some(expiry) = e.expires_at {
+                        max_expiry = expiry;
+                    } else {
+                        // If any of the affected events do not expire, then this event cannot
+                        // expire
+                        return None;
+                    }
+                }
+                Some(max_expiry)
+            }
         }
     }
 }
@@ -1020,6 +1162,12 @@ pub enum AddRemoveReactionResult {
     Success(PushEventResult),
     NoChange,
     MessageNotFound,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EventExpiryDate {
+    timestamp: TimestampMillis,
+    event_index: EventIndex,
 }
 
 #[derive(Copy, Clone)]

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -697,9 +697,11 @@ mod tests {
     #[test]
     fn iter_skips_expired() {
         let mut events = setup_events(Some(2000)); // These will expire at 2000
-        events.set_events_time_to_live(Some(1000));
+        let user_id = Principal::from_slice(&[1]).into();
+
+        events.set_events_time_to_live(user_id, Some(1000), 500);
         push_events(&mut events, 500); // These will expire at 1500
-        events.set_events_time_to_live(Some(1500));
+        events.set_events_time_to_live(user_id, Some(1500), 1000);
         push_events(&mut events, 1000); // These will expire at 2500
 
         let group1 = (0u32..=100).map(EventIndex::from).collect_vec();

--- a/backend/libraries/chat_events/src/chat_events_list.rs
+++ b/backend/libraries/chat_events/src/chat_events_list.rs
@@ -705,8 +705,8 @@ mod tests {
         push_events(&mut events, 1000); // These will expire at 2500
 
         let group1 = (0u32..=100).map(EventIndex::from).collect_vec();
-        let group2 = (101u32..=200).map(EventIndex::from).collect_vec();
-        let group3 = (201u32..=300).map(EventIndex::from).collect_vec();
+        let group2 = (101u32..=201).map(EventIndex::from).collect_vec();
+        let group3 = (202u32..=302).map(EventIndex::from).collect_vec();
 
         let events_reader1 = events.main_events_reader(1250);
         let expected1 = group1.iter().chain(group2.iter()).chain(group3.iter()).copied().collect_vec();

--- a/backend/libraries/chat_events/src/expiring_events.rs
+++ b/backend/libraries/chat_events/src/expiring_events.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use types::{EventIndex, MessageIndex, RangeSet, TimestampMillis, Timestamped};
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct ExpiringEvents {
+    event_expiry_dates: BTreeMap<(TimestampMillis, EventIndex), ()>,
+    // We don't remove message indexes from this map so that we can send expired message ranges
+    // incrementally to the frontend
+    message_expiry_dates: BTreeMap<(TimestampMillis, MessageIndex), ()>,
+    expired_message_ranges: Timestamped<RangeSet<MessageIndex>>,
+}
+
+impl ExpiringEvents {
+    pub fn insert(&mut self, event_index: EventIndex, message_index: Option<MessageIndex>, expires_at: TimestampMillis) {
+        self.event_expiry_dates.insert((expires_at, event_index), ());
+
+        message_index.map(|m| self.message_expiry_dates.insert((expires_at, m), ()));
+    }
+
+    pub fn expired_messages(&self, now: TimestampMillis) -> RangeSet<MessageIndex> {
+        let mut ranges = self.expired_message_ranges.value.clone();
+        for message_index in self.messages_expired_since(self.expired_message_ranges.timestamp, now) {
+            ranges.insert(message_index);
+        }
+        ranges
+    }
+
+    pub fn expired_messages_since(&self, since: TimestampMillis, now: TimestampMillis) -> RangeSet<MessageIndex> {
+        let mut ranges = RangeSet::default();
+        for message_index in self.messages_expired_since(since, now) {
+            ranges.insert(message_index);
+        }
+        ranges
+    }
+
+    pub fn next_message_expiry(&self, now: TimestampMillis) -> Option<TimestampMillis> {
+        self.message_expiry_dates
+            .range((now, MessageIndex::default())..)
+            .next()
+            .map(|((ts, _), _)| *ts)
+    }
+
+    pub fn process_expired_events(&mut self, now: TimestampMillis) -> Vec<EventIndex> {
+        let mut expired_events = Vec::new();
+        while let Some(next) = self.take_next_expired_event(now) {
+            expired_events.push(next);
+        }
+
+        let last_updated = self.expired_message_ranges.timestamp;
+        let expired_messages: Vec<_> = self.messages_expired_since(last_updated, now).collect();
+
+        if !expired_messages.is_empty() {
+            self.expired_message_ranges.update(
+                |ranges| {
+                    for message_index in expired_messages {
+                        ranges.insert(message_index);
+                    }
+                },
+                now,
+            );
+        }
+
+        expired_events
+    }
+
+    fn take_next_expired_event(&mut self, now: TimestampMillis) -> Option<EventIndex> {
+        self.event_expiry_dates
+            .first_entry()
+            .filter(|e| (*e.key()).0 < now)
+            .map(|e| e.remove_entry())
+            .map(|((_, event_index), _)| event_index)
+    }
+
+    fn messages_expired_since(&self, since: TimestampMillis, now: TimestampMillis) -> impl Iterator<Item = MessageIndex> + '_ {
+        self.message_expiry_dates
+            .range((since, MessageIndex::default())..(now, MessageIndex::default()))
+            .map(|((_, message_index), _)| *message_index)
+    }
+}

--- a/backend/libraries/chat_events/src/expiring_events.rs
+++ b/backend/libraries/chat_events/src/expiring_events.rs
@@ -67,7 +67,7 @@ impl ExpiringEvents {
     fn take_next_expired_event(&mut self, now: TimestampMillis) -> Option<EventIndex> {
         self.event_expiry_dates
             .first_entry()
-            .filter(|e| (*e.key()).0 < now)
+            .filter(|e| e.key().0 < now)
             .map(|e| e.remove_entry())
             .map(|((_, event_index), _)| event_index)
     }

--- a/backend/libraries/chat_events/src/lib.rs
+++ b/backend/libraries/chat_events/src/lib.rs
@@ -1,6 +1,7 @@
 mod chat_event_internal;
 mod chat_events;
 mod chat_events_list;
+mod expiring_events;
 
 pub use crate::chat_event_internal::*;
 pub use crate::chat_events::*;

--- a/backend/libraries/chat_events/src/lib.rs
+++ b/backend/libraries/chat_events/src/lib.rs
@@ -1,7 +1,7 @@
+mod chat_event_internal;
 mod chat_events;
 mod chat_events_list;
-mod types;
 
+pub use crate::chat_event_internal::*;
 pub use crate::chat_events::*;
 pub use crate::chat_events_list::*;
-pub use crate::types::*;

--- a/backend/libraries/types/Cargo.toml
+++ b/backend/libraries/types/Cargo.toml
@@ -11,6 +11,7 @@ candid = { workspace = true }
 human_readable = { path = "../human_readable" }
 ic-icrc1 = { workspace = true }
 ic-ledger-types = { workspace = true }
+range-set = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -153,6 +153,7 @@ type DirectChatSummaryUpdates =
         metrics: opt ChatMetrics;
         my_metrics: opt ChatMetrics;
         archived: opt bool;
+        events_ttl: EventsTimeToLiveUpdate;
     };
 
 type DirectMessageNotification =
@@ -308,6 +309,7 @@ type GroupCanisterGroupChatSummary =
         frozen: opt FrozenGroupInfo;
         wasm_version: Version;
         date_last_pinned: opt TimestampMillis;
+        events_ttl: opt Milliseconds;
     };
 
 type GroupChatSummaryUpdates =
@@ -337,6 +339,7 @@ type GroupChatSummaryUpdates =
         wasm_version: opt Version;
         date_last_pinned: opt TimestampMillis;
         date_read_pinned: opt TimestampMillis;
+        events_ttl: EventsTimeToLiveUpdate;
     };
 
 type GroupCanisterGroupChatSummaryUpdates =
@@ -364,6 +367,7 @@ type GroupCanisterGroupChatSummaryUpdates =
         frozen: FrozenGroupUpdate;
         wasm_version: opt Version;
         date_last_pinned: opt TimestampMillis;
+        events_ttl: EventsTimeToLiveUpdate;
     };
 
 type GroupDescriptionChanged =
@@ -1163,6 +1167,13 @@ type EventsTimeToLiveUpdated =
     record {
         updated_by: UserId;
         new_ttl: opt Milliseconds;
+    };
+
+type EventsTimeToLiveUpdate =
+    variant {
+        NoChange;
+        SetToNone;
+        SetToSome: Milliseconds;
     };
 
 type PushEventResult =

--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -139,6 +139,8 @@ type DirectChatSummary =
         metrics: ChatMetrics;
         my_metrics: ChatMetrics;
         archived: bool;
+        events_ttl: opt Milliseconds;
+        expired_messages: vec MessageIndexRange;
     };
 
 type DirectChatSummaryUpdates =
@@ -154,6 +156,7 @@ type DirectChatSummaryUpdates =
         my_metrics: opt ChatMetrics;
         archived: opt bool;
         events_ttl: EventsTimeToLiveUpdate;
+        newly_expired_messages: vec MessageIndexRange;
     };
 
 type DirectMessageNotification =
@@ -280,6 +283,9 @@ type GroupChatSummary =
         wasm_version: Version;
         date_last_pinned: opt TimestampMillis;
         date_read_pinned: opt TimestampMillis;
+        events_ttl: opt Milliseconds;
+        expired_messages: vec MessageIndexRange;
+        next_message_expiry: opt TimestampMillis;
     };
 
 type GroupCanisterGroupChatSummary =
@@ -310,6 +316,8 @@ type GroupCanisterGroupChatSummary =
         wasm_version: Version;
         date_last_pinned: opt TimestampMillis;
         events_ttl: opt Milliseconds;
+        expired_messages: vec MessageIndexRange;
+        next_message_expiry: opt TimestampMillis;
     };
 
 type GroupChatSummaryUpdates =
@@ -339,7 +347,9 @@ type GroupChatSummaryUpdates =
         wasm_version: opt Version;
         date_last_pinned: opt TimestampMillis;
         date_read_pinned: opt TimestampMillis;
-        events_ttl: EventsTimeToLiveUpdate;
+        events_ttl: opt Milliseconds;
+        expired_messages: vec MessageIndexRange;
+        next_message_expiry: TimestampUpdate;
     };
 
 type GroupCanisterGroupChatSummaryUpdates =
@@ -368,6 +378,8 @@ type GroupCanisterGroupChatSummaryUpdates =
         wasm_version: opt Version;
         date_last_pinned: opt TimestampMillis;
         events_ttl: EventsTimeToLiveUpdate;
+        newly_expired_messages: vec MessageIndexRange;
+        next_message_expiry: TimestampUpdate;
     };
 
 type GroupDescriptionChanged =
@@ -403,6 +415,13 @@ type AvatarIdUpdate =
         NoChange;
         SetToNone;
         SetToSome: nat;
+    };
+
+type TimestampUpdate =
+    variant {
+        NoChange;
+        SetToNone;
+        SetToSome: TimestampMillis;
     };
 
 type Mention =
@@ -1181,4 +1200,10 @@ type PushEventResult =
         index: EventIndex;
         timestamp: TimestampMillis;
         expires_at: opt TimestampMillis;
+    };
+
+type MessageIndexRange =
+    record {
+        start: MessageIndex;
+        end: MessageIndex;
     };

--- a/backend/libraries/types/can.did
+++ b/backend/libraries/types/can.did
@@ -237,6 +237,7 @@ type ChatEvent =
         GroupRulesChanged: GroupRulesChanged;
         ChatFrozen: ChatFrozen;
         ChatUnfrozen: ChatUnfrozen;
+        EventsTimeToLiveUpdated: EventsTimeToLiveUpdated;
     };
 
 type ChatEventWrapper =
@@ -1156,6 +1157,12 @@ type ChatFrozen =
 type ChatUnfrozen =
     record {
         unfrozen_by: UserId;
+    };
+
+type EventsTimeToLiveUpdated =
+    record {
+        updated_by: UserId;
+        new_ttl: opt Milliseconds;
     };
 
 type PushEventResult =

--- a/backend/libraries/types/src/chat_summary.rs
+++ b/backend/libraries/types/src/chat_summary.rs
@@ -1,6 +1,6 @@
 use crate::{
     CanisterId, ChatId, EventIndex, EventWrapper, FrozenGroupInfo, GroupPermissions, Mention, Message, MessageIndex,
-    Milliseconds, OptionUpdate, Role, TimestampMillis, UserId, Version, MAX_RETURNED_MENTIONS,
+    Milliseconds, OptionUpdate, RangeSet, Role, TimestampMillis, UserId, Version, MAX_RETURNED_MENTIONS,
 };
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
@@ -46,6 +46,8 @@ pub struct DirectChatSummary {
     pub archived: bool,
     #[serde(default)]
     pub events_ttl: Option<Milliseconds>,
+    #[serde(default)]
+    pub expired_messages: RangeSet<MessageIndex>,
 }
 
 impl DirectChatSummary {
@@ -87,6 +89,10 @@ pub struct GroupChatSummary {
     pub date_read_pinned: Option<TimestampMillis>,
     #[serde(default)]
     pub events_ttl: Option<Milliseconds>,
+    #[serde(default)]
+    pub expired_messages: RangeSet<MessageIndex>,
+    #[serde(default)]
+    pub next_message_expiry: Option<TimestampMillis>,
 }
 
 impl GroupChatSummary {
@@ -125,9 +131,10 @@ pub struct DirectChatSummaryUpdates {
     pub archived: Option<bool>,
     #[serde(default)]
     pub events_ttl: OptionUpdate<Milliseconds>,
+    #[serde(default)]
+    pub newly_expired_messages: RangeSet<MessageIndex>,
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct GroupChatSummaryUpdates {
     pub chat_id: ChatId,
@@ -157,6 +164,10 @@ pub struct GroupChatSummaryUpdates {
     pub date_read_pinned: Option<TimestampMillis>,
     #[serde(default)]
     pub events_ttl: OptionUpdate<Milliseconds>,
+    #[serde(default)]
+    pub newly_expired_messages: RangeSet<MessageIndex>,
+    #[serde(default)]
+    pub next_message_expiry: OptionUpdate<TimestampMillis>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -207,6 +218,10 @@ pub struct GroupCanisterGroupChatSummary {
     pub date_last_pinned: Option<TimestampMillis>,
     #[serde(default)]
     pub events_ttl: Option<Milliseconds>,
+    #[serde(default)]
+    pub expired_messages: RangeSet<MessageIndex>,
+    #[serde(default)]
+    pub next_message_expiry: Option<TimestampMillis>,
 }
 
 impl GroupCanisterGroupChatSummary {
@@ -265,6 +280,8 @@ impl GroupCanisterGroupChatSummary {
             frozen: updates.frozen.apply_to(self.frozen),
             date_last_pinned: updates.date_last_pinned.or(self.date_last_pinned),
             events_ttl: updates.events_ttl.apply_to(self.events_ttl),
+            expired_messages: self.expired_messages.merge(updates.newly_expired_messages),
+            next_message_expiry: updates.next_message_expiry.apply_to(self.next_message_expiry),
         }
     }
 }
@@ -296,6 +313,10 @@ pub struct GroupCanisterGroupChatSummaryUpdates {
     pub date_last_pinned: Option<TimestampMillis>,
     #[serde(default)]
     pub events_ttl: OptionUpdate<Milliseconds>,
+    #[serde(default)]
+    pub newly_expired_messages: RangeSet<MessageIndex>,
+    #[serde(default)]
+    pub next_message_expiry: OptionUpdate<TimestampMillis>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug, Default, Clone)]

--- a/backend/libraries/types/src/chat_summary.rs
+++ b/backend/libraries/types/src/chat_summary.rs
@@ -45,7 +45,7 @@ pub struct DirectChatSummary {
     pub my_metrics: ChatMetrics,
     pub archived: bool,
     #[serde(default)]
-    pub events_ttl: Option<Millisecnds>,
+    pub events_ttl: Option<Milliseconds>,
 }
 
 impl DirectChatSummary {

--- a/backend/libraries/types/src/chat_summary.rs
+++ b/backend/libraries/types/src/chat_summary.rs
@@ -1,6 +1,6 @@
 use crate::{
     CanisterId, ChatId, EventIndex, EventWrapper, FrozenGroupInfo, GroupPermissions, Mention, Message, MessageIndex,
-    OptionUpdate, Role, TimestampMillis, UserId, Version, MAX_RETURNED_MENTIONS,
+    Milliseconds, OptionUpdate, Role, TimestampMillis, UserId, Version, MAX_RETURNED_MENTIONS,
 };
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
@@ -44,6 +44,8 @@ pub struct DirectChatSummary {
     pub metrics: ChatMetrics,
     pub my_metrics: ChatMetrics,
     pub archived: bool,
+    #[serde(default)]
+    pub events_ttl: Option<Millisecnds>,
 }
 
 impl DirectChatSummary {
@@ -83,6 +85,8 @@ pub struct GroupChatSummary {
     pub frozen: Option<FrozenGroupInfo>,
     pub date_last_pinned: Option<TimestampMillis>,
     pub date_read_pinned: Option<TimestampMillis>,
+    #[serde(default)]
+    pub events_ttl: Option<Milliseconds>,
 }
 
 impl GroupChatSummary {
@@ -119,6 +123,8 @@ pub struct DirectChatSummaryUpdates {
     pub metrics: Option<ChatMetrics>,
     pub my_metrics: Option<ChatMetrics>,
     pub archived: Option<bool>,
+    #[serde(default)]
+    pub events_ttl: OptionUpdate<Milliseconds>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -149,6 +155,8 @@ pub struct GroupChatSummaryUpdates {
     pub frozen: OptionUpdate<FrozenGroupInfo>,
     pub date_last_pinned: Option<TimestampMillis>,
     pub date_read_pinned: Option<TimestampMillis>,
+    #[serde(default)]
+    pub events_ttl: OptionUpdate<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -166,6 +174,8 @@ pub struct PublicGroupSummary {
     pub owner_id: UserId,
     pub is_public: bool,
     pub frozen: Option<FrozenGroupInfo>,
+    #[serde(default)]
+    pub events_ttl: Option<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -195,6 +205,8 @@ pub struct GroupCanisterGroupChatSummary {
     pub latest_threads: Vec<GroupCanisterThreadDetails>,
     pub frozen: Option<FrozenGroupInfo>,
     pub date_last_pinned: Option<TimestampMillis>,
+    #[serde(default)]
+    pub events_ttl: Option<Milliseconds>,
 }
 
 impl GroupCanisterGroupChatSummary {
@@ -252,41 +264,7 @@ impl GroupCanisterGroupChatSummary {
             latest_threads,
             frozen: updates.frozen.apply_to(self.frozen),
             date_last_pinned: updates.date_last_pinned.or(self.date_last_pinned),
-        }
-    }
-}
-
-impl From<GroupCanisterGroupChatSummary> for GroupChatSummary {
-    fn from(s: GroupCanisterGroupChatSummary) -> Self {
-        GroupChatSummary {
-            chat_id: s.chat_id,
-            last_updated: s.last_updated,
-            name: s.name,
-            description: s.description,
-            subtype: s.subtype,
-            avatar_id: s.avatar_id,
-            is_public: s.is_public,
-            history_visible_to_new_joiners: s.history_visible_to_new_joiners,
-            min_visible_event_index: s.min_visible_event_index,
-            min_visible_message_index: s.min_visible_message_index,
-            latest_message: s.latest_message,
-            latest_event_index: s.latest_event_index,
-            joined: s.joined,
-            read_by_me_up_to: None,
-            notifications_muted: s.notifications_muted,
-            participant_count: s.participant_count,
-            role: s.role,
-            mentions: s.mentions,
-            wasm_version: s.wasm_version,
-            owner_id: s.owner_id,
-            permissions: s.permissions,
-            metrics: s.metrics,
-            my_metrics: s.my_metrics,
-            latest_threads: s.latest_threads.into_iter().map(|t| t.into()).collect(),
-            archived: false,
-            frozen: s.frozen,
-            date_last_pinned: s.date_last_pinned,
-            date_read_pinned: None,
+            events_ttl: updates.events_ttl.apply_to(self.events_ttl),
         }
     }
 }
@@ -316,38 +294,8 @@ pub struct GroupCanisterGroupChatSummaryUpdates {
     pub notifications_muted: Option<bool>,
     pub frozen: OptionUpdate<FrozenGroupInfo>,
     pub date_last_pinned: Option<TimestampMillis>,
-}
-
-impl From<GroupCanisterGroupChatSummaryUpdates> for GroupChatSummaryUpdates {
-    fn from(s: GroupCanisterGroupChatSummaryUpdates) -> Self {
-        GroupChatSummaryUpdates {
-            chat_id: s.chat_id,
-            last_updated: s.last_updated,
-            name: s.name,
-            description: s.description,
-            subtype: s.subtype,
-            avatar_id: s.avatar_id,
-            latest_message: s.latest_message,
-            latest_event_index: s.latest_event_index,
-            participant_count: s.participant_count,
-            role: s.role,
-            read_by_me_up_to: None,
-            notifications_muted: s.notifications_muted,
-            mentions: s.mentions,
-            wasm_version: s.wasm_version,
-            owner_id: s.owner_id,
-            permissions: s.permissions,
-            affected_events: s.affected_events,
-            metrics: s.metrics,
-            my_metrics: s.my_metrics,
-            is_public: s.is_public,
-            latest_threads: s.latest_threads.into_iter().map(|t| t.into()).collect(),
-            archived: None,
-            frozen: s.frozen,
-            date_last_pinned: s.date_last_pinned,
-            date_read_pinned: None,
-        }
-    }
+    #[serde(default)]
+    pub events_ttl: OptionUpdate<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug, Default, Clone)]

--- a/backend/libraries/types/src/event_wrapper.rs
+++ b/backend/libraries/types/src/event_wrapper.rs
@@ -11,3 +11,9 @@ pub struct EventWrapper<T: CandidType + Clone + Debug> {
     pub expires_at: Option<TimestampMillis>,
     pub event: T,
 }
+
+impl<T: CandidType + Clone + Debug> EventWrapper<T> {
+    pub fn is_expired(&self, now: TimestampMillis) -> bool {
+        self.expires_at.map_or(false, |expiry| expiry < now)
+    }
+}

--- a/backend/libraries/types/src/events.rs
+++ b/backend/libraries/types/src/events.rs
@@ -1,4 +1,4 @@
-use crate::{EventIndex, GroupPermissions, Message, MessageId, MessageIndex, Role, UserId};
+use crate::{EventIndex, GroupPermissions, Message, MessageId, MessageIndex, Milliseconds, Role, UserId};
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
 
@@ -39,6 +39,7 @@ pub enum ChatEvent {
     ProposalsUpdated(ProposalsUpdated),
     ChatFrozen(ChatFrozen),
     ChatUnfrozen(ChatUnfrozen),
+    EventsTimeToLiveUpdated(EventsTimeToLiveUpdated),
 }
 
 impl ChatEvent {
@@ -245,6 +246,12 @@ pub struct ChatFrozen {
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct ChatUnfrozen {
     pub unfrozen_by: UserId,
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+pub struct EventsTimeToLiveUpdated {
+    pub updated_by: UserId,
+    pub new_ttl: Option<Milliseconds>,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Copy, Clone, Debug)]

--- a/backend/libraries/types/src/lib.rs
+++ b/backend/libraries/types/src/lib.rs
@@ -35,6 +35,7 @@ mod participant;
 mod phone_number;
 mod polls;
 mod proposals;
+mod range_set;
 mod reactions;
 mod registration_fee;
 mod role;
@@ -46,6 +47,7 @@ mod user;
 mod user_summary;
 mod version;
 
+pub use crate::range_set::*;
 pub use avatar::*;
 pub use bots::*;
 pub use canister_upgrade_status::*;

--- a/backend/libraries/types/src/message_content.rs
+++ b/backend/libraries/types/src/message_content.rs
@@ -388,7 +388,7 @@ pub struct DeletedBy {
     pub timestamp: TimestampMillis,
 }
 
-#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct BlobReference {
     pub canister_id: CanisterId,
     pub blob_id: u128,

--- a/backend/libraries/types/src/range_set.rs
+++ b/backend/libraries/types/src/range_set.rs
@@ -31,6 +31,12 @@ impl<T> RangeSet<T> {
     }
 }
 
+impl<T: From<u32>> RangeSet<T> {
+    pub fn iter(&self) -> impl Iterator<Item = T> + '_ {
+        self.ranges.iter().map(T::from)
+    }
+}
+
 impl<T> Default for RangeSet<T> {
     fn default() -> Self {
         RangeSet {

--- a/backend/libraries/types/src/range_set.rs
+++ b/backend/libraries/types/src/range_set.rs
@@ -1,0 +1,130 @@
+use candid::types::{Serializer, Type};
+use candid::CandidType;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+use std::ops::RangeInclusive;
+
+type RangeSetInner = range_set::RangeSet<[RangeInclusive<u32>; 2]>;
+
+pub struct RangeSet<T> {
+    ranges: RangeSetInner,
+    phantom: PhantomData<T>,
+}
+
+impl<T: Into<u32> + From<u32>> RangeSet<T> {
+    pub fn insert(&mut self, value: T) {
+        self.ranges.insert(value.into());
+    }
+
+    pub fn merge(mut self, other: Self) -> RangeSet<T> {
+        for range in other.ranges.ranges() {
+            self.ranges.insert_range(range.clone());
+        }
+        self
+    }
+}
+
+impl<T> RangeSet<T> {
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+}
+
+impl<T> Default for RangeSet<T> {
+    fn default() -> Self {
+        RangeSet {
+            ranges: RangeSetInner::new(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: CandidType + Into<u32>> CandidType for RangeSet<T> {
+    fn _ty() -> Type {
+        Vec::<Range>::_ty()
+    }
+
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: Serializer,
+    {
+        let vec: Vec<Range> = self.into();
+
+        vec.idl_serialize(serializer)
+    }
+}
+
+impl<T: Into<u32>> Serialize for RangeSet<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let vec: Vec<Range> = self.into();
+
+        vec.serialize(serializer)
+    }
+}
+
+impl<'de, T: From<u32>> Deserialize<'de> for RangeSet<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let vec: Vec<Range> = Vec::deserialize(deserializer)?;
+
+        Ok(vec.into())
+    }
+}
+
+#[derive(CandidType, Serialize, Deserialize, Debug)]
+struct Range {
+    start: u32,
+    end: u32,
+}
+
+impl<T: Into<u32>> From<&RangeSet<T>> for Vec<Range> {
+    fn from(value: &RangeSet<T>) -> Self {
+        value
+            .ranges
+            .ranges()
+            .map(|r| Range {
+                start: (*r.start()).into(),
+                end: (*r.end()).into(),
+            })
+            .collect()
+    }
+}
+
+impl<T: From<u32>> From<Vec<Range>> for RangeSet<T> {
+    fn from(value: Vec<Range>) -> Self {
+        let mut range_set = RangeSet::default();
+        for range in value {
+            range_set.ranges.insert_range(range.into());
+        }
+        range_set
+    }
+}
+
+impl From<Range> for RangeInclusive<u32> {
+    fn from(value: Range) -> Self {
+        RangeInclusive::new(value.start, value.end)
+    }
+}
+
+impl<T: Into<u32>> Debug for RangeSet<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let ranges: Vec<Range> = self.into();
+
+        ranges.fmt(f)
+    }
+}
+
+impl<T> Clone for RangeSet<T> {
+    fn clone(&self) -> Self {
+        RangeSet {
+            ranges: self.ranges.clone(),
+            phantom: PhantomData,
+        }
+    }
+}

--- a/backend/libraries/types/src/range_set.rs
+++ b/backend/libraries/types/src/range_set.rs
@@ -56,7 +56,6 @@ impl<T: CandidType + Into<u32>> CandidType for RangeSet<T> {
         S: Serializer,
     {
         let vec: Vec<Range> = self.into();
-
         vec.idl_serialize(serializer)
     }
 }
@@ -67,7 +66,6 @@ impl<T: Into<u32>> Serialize for RangeSet<T> {
         S: serde::Serializer,
     {
         let vec: Vec<Range> = self.into();
-
         vec.serialize(serializer)
     }
 }
@@ -78,7 +76,6 @@ impl<'de, T: From<u32>> Deserialize<'de> for RangeSet<T> {
         D: Deserializer<'de>,
     {
         let vec: Vec<Range> = Vec::deserialize(deserializer)?;
-
         Ok(vec.into())
     }
 }

--- a/backend/libraries/types/src/range_set.rs
+++ b/backend/libraries/types/src/range_set.rs
@@ -89,8 +89,8 @@ impl<T: Into<u32>> From<&RangeSet<T>> for Vec<Range> {
             .ranges
             .ranges()
             .map(|r| Range {
-                start: (*r.start()).into(),
-                end: (*r.end()).into(),
+                start: *r.start(),
+                end: *r.end(),
             })
             .collect()
     }

--- a/backend/libraries/types/src/timestamped.rs
+++ b/backend/libraries/types/src/timestamped.rs
@@ -22,6 +22,11 @@ impl<T> Timestamped<T> {
             None
         }
     }
+
+    pub fn update<F: FnOnce(&mut T)>(&mut self, update_fn: F, now: TimestampMillis) {
+        update_fn(&mut self.value);
+        self.timestamp = now;
+    }
 }
 
 impl<T: Default> Default for Timestamped<T> {

--- a/frontend/app/src/components/home/ChatEvent.svelte
+++ b/frontend/app/src/components/home/ChatEvent.svelte
@@ -220,6 +220,6 @@
     <ChatFrozenEvent user={userSummary} event={event.event} timestamp={event.timestamp} />
 {:else if event.event.kind === "chat_unfrozen"}
     <ChatUnfrozenEvent user={userSummary} event={event.event} timestamp={event.timestamp} />
-{:else if event.event.kind !== "reaction_added" && event.event.kind !== "reaction_removed" && event.event.kind !== "message_pinned" && event.event.kind !== "message_unpinned" && event.event.kind !== "poll_ended" && event.event.kind !== "member_joined" && event.event.kind !== "member_left"}
+{:else if event.event.kind !== "reaction_added" && event.event.kind !== "reaction_removed" && event.event.kind !== "message_pinned" && event.event.kind !== "message_unpinned" && event.event.kind !== "poll_ended" && event.event.kind !== "member_joined" && event.event.kind !== "member_left" && event.event.kind !== "events_ttl_updated"}
     <div>Unexpected event type</div>
 {/if}

--- a/frontend/openchat-agent/src/services/group/candid/idl.js
+++ b/frontend/openchat-agent/src/services/group/candid/idl.js
@@ -543,6 +543,11 @@ export const idlFactory = ({ IDL }) => {
     'old_role' : Role,
     'new_role' : Role,
   });
+  const Milliseconds = IDL.Nat64;
+  const EventsTimeToLiveUpdated = IDL.Record({
+    'new_ttl' : IDL.Opt(Milliseconds),
+    'updated_by' : UserId,
+  });
   const ProposalUpdated = IDL.Record({
     'event_index' : EventIndex,
     'message_index' : MessageIndex,
@@ -595,6 +600,7 @@ export const idlFactory = ({ IDL }) => {
     'MessageUndeleted' : UpdatedMessage,
     'RoleChanged' : RoleChanged,
     'PollVoteDeleted' : UpdatedMessage,
+    'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated,
     'ProposalsUpdated' : ProposalsUpdated,
     'OwnershipTransferred' : OwnershipTransferred,
     'DirectChatCreated' : DirectChatCreated,
@@ -1083,6 +1089,11 @@ export const idlFactory = ({ IDL }) => {
     'reply_in_thread' : IDL.Opt(PermissionRole),
     'react_to_messages' : IDL.Opt(PermissionRole),
   });
+  const EventsTimeToLiveUpdate = IDL.Variant({
+    'NoChange' : IDL.Null,
+    'SetToNone' : IDL.Null,
+    'SetToSome' : Milliseconds,
+  });
   const Avatar = IDL.Record({
     'id' : IDL.Nat,
     'data' : IDL.Vec(IDL.Nat8),
@@ -1097,6 +1108,7 @@ export const idlFactory = ({ IDL }) => {
     'permissions' : IDL.Opt(OptionalGroupPermissions),
     'name' : IDL.Opt(IDL.Text),
     'description' : IDL.Opt(IDL.Text),
+    'events_ttl' : EventsTimeToLiveUpdate,
     'correlation_id' : IDL.Nat64,
     'rules' : IDL.Opt(GroupRules),
     'avatar' : AvatarUpdate,

--- a/frontend/openchat-agent/src/services/group/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/group/candid/types.d.ts
@@ -143,6 +143,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -323,6 +324,13 @@ export interface EventsSuccessResult {
   'affected_events' : Array<ChatEventWrapper>,
   'events' : Array<ChatEventWrapper>,
   'latest_event_index' : number,
+}
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
 }
 export interface EventsWindowArgs {
   'latest_client_event_index' : [] | [EventIndex],
@@ -1173,6 +1181,7 @@ export interface UpdateGroupV2Args {
   'permissions' : [] | [OptionalGroupPermissions],
   'name' : [] | [string],
   'description' : [] | [string],
+  'events_ttl' : EventsTimeToLiveUpdate,
   'correlation_id' : bigint,
   'rules' : [] | [GroupRules],
   'avatar' : AvatarUpdate,

--- a/frontend/openchat-agent/src/services/group/group.caching.client.ts
+++ b/frontend/openchat-agent/src/services/group/group.caching.client.ts
@@ -39,6 +39,7 @@ import type {
     Logger,
     DeletedGroupMessageResponse,
     EventWrapper,
+    OptionUpdate,
 } from "openchat-shared";
 import type { IGroupClient } from "./group.client.interface";
 import type { IDBPDatabase } from "idb";
@@ -245,9 +246,10 @@ export class CachingGroupClient implements IGroupClient {
         description?: string,
         rules?: GroupRules,
         permissions?: Partial<GroupPermissions>,
-        avatar?: Uint8Array
+        avatar?: Uint8Array,
+        eventsTimeToLiveMs?: OptionUpdate<bigint>,
     ): Promise<UpdateGroupResponse> {
-        return this.client.updateGroup(name, description, rules, permissions, avatar);
+        return this.client.updateGroup(name, description, rules, permissions, avatar, eventsTimeToLiveMs);
     }
 
     addReaction(

--- a/frontend/openchat-agent/src/services/group/group.client.interface.ts
+++ b/frontend/openchat-agent/src/services/group/group.client.interface.ts
@@ -36,6 +36,7 @@ import type {
     GroupCanisterSummaryUpdatesResponse,
     DeletedGroupMessageResponse,
     EventWrapper,
+    OptionUpdate,
 } from "openchat-shared";
 
 export interface IGroupClient {
@@ -77,7 +78,8 @@ export interface IGroupClient {
         desc?: string,
         rules?: GroupRules,
         permissions?: Partial<GroupPermissions>,
-        avatar?: Uint8Array
+        avatar?: Uint8Array,
+        eventsTimeToLiveMs?: OptionUpdate<bigint>,
     ): Promise<UpdateGroupResponse>;
     addReaction(
         messageId: bigint,

--- a/frontend/openchat-agent/src/services/group/group.client.ts
+++ b/frontend/openchat-agent/src/services/group/group.client.ts
@@ -39,6 +39,7 @@ import {
     GroupCanisterSummaryUpdatesResponse,
     DeletedGroupMessageResponse,
     EventWrapper,
+    OptionUpdate,
 } from "openchat-shared";
 import { CandidService } from "../candidService";
 import {
@@ -86,6 +87,7 @@ import { identity, mergeGroupChatDetails } from "../../utils/chat";
 import { MAX_EVENTS, MAX_MESSAGES } from "../../constants";
 import { profile } from "../common/profiling";
 import { publicSummaryResponse } from "../common/publicSummaryMapper";
+import { apiOptionUpdate } from "../../utils/mapping";
 import { generateUint64 } from "../../utils/rng";
 import type { AgentConfig } from "../../config";
 
@@ -324,7 +326,8 @@ export class GroupClient extends CandidService implements IGroupClient {
         description?: string,
         rules?: GroupRules,
         permissions?: Partial<GroupPermissions>,
-        avatar?: Uint8Array
+        avatar?: Uint8Array,
+        eventsTimeToLiveMs?: OptionUpdate<bigint>,
     ): Promise<UpdateGroupResponse> {
         return this.handleResponse(
             this.groupService.update_group_v2({
@@ -342,6 +345,7 @@ export class GroupClient extends CandidService implements IGroupClient {
                           },
                 permissions: apiOptional(apiOptionalGroupPermissions, permissions),
                 rules: apiOptional(apiGroupRules, rules),
+                events_ttl: apiOptionUpdate(identity, eventsTimeToLiveMs),
                 correlation_id: generateUint64(),
             }),
             updateGroupResponse

--- a/frontend/openchat-agent/src/services/group/mappers.ts
+++ b/frontend/openchat-agent/src/services/group/mappers.ts
@@ -1352,6 +1352,14 @@ function groupChatEvent(candid: ApiGroupChatEvent): GroupChatEvent {
         };
     }
 
+    if ("EventsTimeToLiveUpdated" in candid) {
+        return {
+            kind: "events_ttl_updated",
+            updatedBy: candid.EventsTimeToLiveUpdated.updated_by.toString(),
+            newTimeToLive: optional(candid.EventsTimeToLiveUpdated.new_ttl, identity)
+        }
+    }
+
     throw new UnsupportedValueError("Unexpected ApiEventWrapper type received", candid);
 }
 

--- a/frontend/openchat-agent/src/services/groupIndex/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/groupIndex/candid/types.d.ts
@@ -72,6 +72,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -195,6 +196,13 @@ export interface DirectReactionAddedNotification {
   'reaction' : string,
 }
 export type EventIndex = number;
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
+}
 export type FailedCryptoTransaction = { 'NNS' : NnsFailedCryptoTransaction } |
   { 'SNS' : SnsFailedCryptoTransaction };
 export type FallbackRole = { 'Participant' : null } |

--- a/frontend/openchat-agent/src/services/localUserIndex/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/localUserIndex/candid/types.d.ts
@@ -72,6 +72,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -188,6 +189,13 @@ export interface DirectReactionAddedNotification {
   'reaction' : string,
 }
 export type EventIndex = number;
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
+}
 export type FailedCryptoTransaction = { 'NNS' : NnsFailedCryptoTransaction } |
   { 'SNS' : SnsFailedCryptoTransaction };
 export type FallbackRole = { 'Participant' : null } |

--- a/frontend/openchat-agent/src/services/notifications/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/notifications/candid/types.d.ts
@@ -72,6 +72,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -188,6 +189,13 @@ export interface DirectReactionAddedNotification {
   'reaction' : string,
 }
 export type EventIndex = number;
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
+}
 export type FailedCryptoTransaction = { 'NNS' : NnsFailedCryptoTransaction } |
   { 'SNS' : SnsFailedCryptoTransaction };
 export type FallbackRole = { 'Participant' : null } |

--- a/frontend/openchat-agent/src/services/online/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/online/candid/types.d.ts
@@ -72,6 +72,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -188,6 +189,13 @@ export interface DirectReactionAddedNotification {
   'reaction' : string,
 }
 export type EventIndex = number;
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
+}
 export type FailedCryptoTransaction = { 'NNS' : NnsFailedCryptoTransaction } |
   { 'SNS' : SnsFailedCryptoTransaction };
 export type FallbackRole = { 'Participant' : null } |

--- a/frontend/openchat-agent/src/services/user/candid/idl.js
+++ b/frontend/openchat-agent/src/services/user/candid/idl.js
@@ -553,6 +553,10 @@ export const idlFactory = ({ IDL }) => {
     'old_role' : Role,
     'new_role' : Role,
   });
+  const EventsTimeToLiveUpdated = IDL.Record({
+    'new_ttl' : IDL.Opt(Milliseconds),
+    'updated_by' : UserId,
+  });
   const ProposalUpdated = IDL.Record({
     'event_index' : EventIndex,
     'message_index' : MessageIndex,
@@ -605,6 +609,7 @@ export const idlFactory = ({ IDL }) => {
     'MessageUndeleted' : UpdatedMessage,
     'RoleChanged' : RoleChanged,
     'PollVoteDeleted' : UpdatedMessage,
+    'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated,
     'ProposalsUpdated' : ProposalsUpdated,
     'OwnershipTransferred' : OwnershipTransferred,
     'DirectChatCreated' : DirectChatCreated,

--- a/frontend/openchat-agent/src/services/user/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/user/candid/types.d.ts
@@ -110,6 +110,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -317,6 +318,13 @@ export interface EventsSuccessResult {
   'affected_events' : Array<ChatEventWrapper>,
   'events' : Array<ChatEventWrapper>,
   'latest_event_index' : EventIndex,
+}
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
 }
 export interface EventsWindowArgs {
   'latest_client_event_index' : [] | [EventIndex],

--- a/frontend/openchat-agent/src/services/userIndex/candid/types.d.ts
+++ b/frontend/openchat-agent/src/services/userIndex/candid/types.d.ts
@@ -79,6 +79,7 @@ export type ChatEvent = { 'MessageReactionRemoved' : UpdatedMessage } |
   { 'MessageUndeleted' : UpdatedMessage } |
   { 'RoleChanged' : RoleChanged } |
   { 'PollVoteDeleted' : UpdatedMessage } |
+  { 'EventsTimeToLiveUpdated' : EventsTimeToLiveUpdated } |
   { 'ProposalsUpdated' : ProposalsUpdated } |
   { 'OwnershipTransferred' : OwnershipTransferred } |
   { 'DirectChatCreated' : DirectChatCreated } |
@@ -228,6 +229,13 @@ export interface DirectReactionAddedNotification {
   'reaction' : string,
 }
 export type EventIndex = number;
+export type EventsTimeToLiveUpdate = { 'NoChange' : null } |
+  { 'SetToNone' : null } |
+  { 'SetToSome' : Milliseconds };
+export interface EventsTimeToLiveUpdated {
+  'new_ttl' : [] | [Milliseconds],
+  'updated_by' : UserId,
+}
 export type FailedCryptoTransaction = { 'NNS' : NnsFailedCryptoTransaction } |
   { 'SNS' : SnsFailedCryptoTransaction };
 export type FallbackRole = { 'Participant' : null } |

--- a/frontend/openchat-agent/src/utils/mapping.ts
+++ b/frontend/openchat-agent/src/utils/mapping.ts
@@ -15,6 +15,15 @@ export function optionUpdate<A, B>(
     throw new UnsupportedValueError("Unexpected ApiOptionUpdate type returned", candid);
 }
 
+export function apiOptionUpdate<A, B>(
+    mapper: (a: A) => B,
+    domain: OptionUpdate<A>
+): ApiOptionUpdate<B> {
+    if (domain === undefined) return { NoChange: null };
+    if (domain === "set_to_none") return { SetToNone: null };
+    return { SetToSome: mapper(domain.value) };
+}
+
 export function applyOptionUpdate<T>(
     original: T | undefined,
     update: OptionUpdate<T>

--- a/frontend/openchat-client/src/utils/chat.ts
+++ b/frontend/openchat-client/src/utils/chat.ts
@@ -160,6 +160,8 @@ export function activeUserIdFromEvent(event: ChatEvent): string | undefined {
             return event.pinnedBy;
         case "message_unpinned":
             return event.unpinnedBy;
+        case "events_ttl_updated":
+            return event.updatedBy;
         case "message_deleted":
         case "message_undeleted":
         case "message_edited":

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -446,7 +446,8 @@ export type GroupChatEvent =
     | ThreadUpdated
     | ProposalsUpdated
     | ChatFrozenEvent
-    | ChatUnfrozenEvent;
+    | ChatUnfrozenEvent
+    | EventsTimeToLiveUpdated;
 
 export type ChatEvent = GroupChatEvent | DirectChatEvent;
 
@@ -1261,6 +1262,12 @@ export type ChatUnfrozenEvent = {
     kind: "chat_unfrozen";
     unfrozenBy: string;
 };
+
+export type EventsTimeToLiveUpdated = {
+    kind: "events_ttl_updated";
+    updatedBy: string;
+    newTimeToLive: bigint | undefined;
+}
 
 export type SetAvatarResponse = "avatar_too_big" | "success" | "internal_error" | "user_suspended";
 

--- a/frontend/openchat-shared/src/utils/chat.ts
+++ b/frontend/openchat-shared/src/utils/chat.ts
@@ -75,6 +75,9 @@ export function userIdsFromEvents(events: EventWrapper<ChatEvent>[]): Set<string
             case "message_unpinned":
                 userIds.add(e.event.unpinnedBy);
                 break;
+            case "events_ttl_updated":
+                userIds.add(e.event.updatedBy);
+                break;
             case "message_deleted":
             case "message_undeleted":
             case "message_edited":


### PR DESCRIPTION
Support for disappearing messages in direct chats will follow in a subsequent PR, this is a bit more complex because there are 2 sources of truth since the data is stored in both user's canisters.
Also for direct chats we can probably make the messages disappear some time after they're read rather than some time after they've sent (or maybe take both into account?).