### PR TITLE
Remove calls to `ic_cdk::setup`

### DIFF
--- a/backend/bots/examples/icp_dispenser/impl/src/lifecycle/init.rs
+++ b/backend/bots/examples/icp_dispenser/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::Environment;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
 
     let env = Box::new(CanisterEnv::new());

--- a/backend/bots/examples/icp_dispenser/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/bots/examples/icp_dispenser/impl/src/lifecycle/post_upgrade.rs
@@ -11,8 +11,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/bots/examples/sns1_airdrop/impl/src/lifecycle/init.rs
+++ b/backend/bots/examples/sns1_airdrop/impl/src/lifecycle/init.rs
@@ -9,7 +9,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
 
     let env = Box::new(CanisterEnv::new());

--- a/backend/bots/examples/sns1_airdrop/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/bots/examples/sns1_airdrop/impl/src/lifecycle/post_upgrade.rs
@@ -11,8 +11,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/group/impl/src/lifecycle/init.rs
+++ b/backend/canisters/group/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::Environment;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
 
     let env = Box::new(CanisterEnv::new());

--- a/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group/impl/src/lifecycle/post_upgrade.rs
@@ -11,8 +11,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (mut data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/group_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/group_index/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/local_group_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/local_group_index/impl/src/lifecycle/init.rs
@@ -12,7 +12,6 @@ const CANISTER_POOL_TARGET_SIZE: u16 = 20;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/local_group_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/local_group_index/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/local_user_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/local_user_index/impl/src/lifecycle/init.rs
@@ -12,7 +12,6 @@ const CANISTER_POOL_TARGET_SIZE: u16 = 20;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/local_user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/local_user_index/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/notifications/impl/src/lifecycle/init.rs
+++ b/backend/canisters/notifications/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/notifications/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/notifications/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/notifications_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/notifications_index/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/notifications_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/notifications_index/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/online_users/impl/src/lifecycle/init.rs
+++ b/backend/canisters/online_users/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/online_users/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/online_users/impl/src/lifecycle/post_upgrade.rs
@@ -13,8 +13,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let memory = get_upgrades_memory();

--- a/backend/canisters/proposals_bot/impl/src/lifecycle/init.rs
+++ b/backend/canisters/proposals_bot/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/proposals_bot/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/proposals_bot/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/user/impl/src/lifecycle/init.rs
+++ b/backend/canisters/user/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::Environment;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
 
     let env = Box::new(CanisterEnv::new());

--- a/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user/impl/src/lifecycle/post_upgrade.rs
@@ -11,8 +11,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (mut data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =

--- a/backend/canisters/user_index/impl/src/lifecycle/init.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/init.rs
@@ -10,7 +10,6 @@ use utils::env::canister::CanisterEnv;
 #[init]
 #[trace]
 fn init(args: Args) {
-    ic_cdk::setup();
     canister_logger::init(args.test_mode);
     init_cycles_dispenser_client(args.cycles_dispenser_canister_id);
 

--- a/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/user_index/impl/src/lifecycle/post_upgrade.rs
@@ -12,8 +12,6 @@ use utils::env::canister::CanisterEnv;
 #[post_upgrade]
 #[trace]
 fn post_upgrade(args: Args) {
-    ic_cdk::setup();
-
     let env = Box::new(CanisterEnv::new());
 
     let (data, logs, traces): (Data, Vec<LogEntry>, Vec<LogEntry>) =


### PR DESCRIPTION
These aren't needed because the cdk calls `setup` at the start of the code output by each of the cdk macros.
https://github.com/dfinity/cdk-rs/blob/0ee7a3c630fb635b8c8a843317d68d439f4a5408/src/ic-cdk-macros/src/export.rs#L200