### PR TITLE
Improved cache handling

### DIFF
--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -981,7 +981,9 @@ export class OpenChatAgent extends EventTarget {
         const affectedEvents = getAffectedEvents(userResponse.directChatsUpdated, groupUpdates);
 
         return await this.hydrateChatState(state).then((s) => {
-            setCachedChatsV2(this.db, this.principal, s, affectedEvents);
+            if (anyUpdates) {
+                setCachedChatsV2(this.db, this.principal, s, affectedEvents);
+            }
 
             return {
                 state: s,


### PR DESCRIPTION
This PR makes 2 changes

1 - Only write to the cache if there have been any updates
2 - Don't write latest messages taken from the chat summaries to the cache, since the `cachePrimer` already get the latest events for any updated chats and writes them to the cache. Prior to the commit, the latest messages would be overwritten on every updates loop, which is unnecessary.