### PR TITLE
Invert scroll direction in chat event lists

### DIFF
--- a/frontend/app/src/components/home/AggregateCommonEvents.svelte
+++ b/frontend/app/src/components/home/AggregateCommonEvents.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
     import type { OpenChat, UserLookup, UserSummary } from "openchat-client";
-    import { afterUpdate, createEventDispatcher, getContext, onDestroy, onMount } from "svelte";
+    import { afterUpdate, getContext, onDestroy, onMount } from "svelte";
     import { _ } from "svelte-i18n";
     import Markdown from "./Markdown.svelte";
 
@@ -15,7 +15,6 @@
 
     let deletedMessagesElement: HTMLElement;
 
-    const dispatch = createEventDispatcher();
     const client = getContext<OpenChat>("client");
 
     $: userStore = client.userStore;
@@ -74,11 +73,7 @@
     }
 
     function expandDeletedMessages() {
-        const chatMessages = document.getElementById("chat-messages");
-        const scrollTop = chatMessages?.scrollTop ?? 0;
-        const scrollHeight = chatMessages?.scrollHeight ?? 0;
         client.expandDeletedMessages(chatId, new Set(messagesDeleted));
-        dispatch("expandDeletedMessages", { scrollTop, scrollHeight });
     }
 </script>
 

--- a/frontend/app/src/components/home/ChatEvent.svelte
+++ b/frontend/app/src/components/home/ChatEvent.svelte
@@ -167,8 +167,7 @@
         {readByMe}
         user={userSummary}
         joined={event.event.usersJoined}
-        messagesDeleted={event.event.messagesDeleted}
-        on:expandDeletedMessages />
+        messagesDeleted={event.event.messagesDeleted} />
 {:else if event.event.kind === "role_changed"}
     <RoleChangedEvent user={userSummary} event={event.event} timestamp={event.timestamp} />
 {:else if event.event.kind === "users_blocked"}

--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -313,10 +313,7 @@
                 interruptScroll(() => {
                     if (messagesDiv !== undefined && previousScrollTop !== undefined) {
                         let adjusted = messagesDiv.scrollTop + scrollHeightDiff;
-                        // Note - logically you would expect this to be adjusted like this:
-                        // let adjusted = messagesDiv.scrollTop + diffDiff;
-                        // But for some reason that doesn't work as well (trust me) :shrug:
-                        // This is still not great on iphone. I would like to know the correlation between scrollHeightDiff and scrollTopDiff
+                        // This is still not great on iphone particularly in the groups that have a high proportion of non-message events
                         messagesDiv.scrollTop = adjusted;
                         console.debug("SCROLL: adjusted: ", {
                             ...keyMeasurements(),

--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -284,14 +284,6 @@
         }
     }
 
-    // TODO - come back to this
-    export function adjust(scrollHeight: number, scrollTop: number) {
-        const diff = (messagesDiv?.scrollHeight ?? 0) - scrollHeight;
-        interruptScroll(() => {
-            messagesDiv?.scrollTo({ top: scrollTop - diff, behavior: "auto" });
-        });
-    }
-
     export async function onMessageWindowLoaded(messageIndex: number | undefined) {
         if (messageIndex === undefined) return;
         await tick();
@@ -319,11 +311,12 @@
             // sometimes chrome is *a little* out but it we only want to intervene if if's way off
             if (diffDiff > sensitivityThreshold) {
                 interruptScroll(() => {
-                    if (messagesDiv !== undefined) {
+                    if (messagesDiv !== undefined && previousScrollTop !== undefined) {
                         let adjusted = messagesDiv.scrollTop + scrollHeightDiff;
                         // Note - logically you would expect this to be adjusted like this:
                         // let adjusted = messagesDiv.scrollTop + diffDiff;
                         // But for some reason that doesn't work as well (trust me) :shrug:
+                        // This is still not great on iphone. I would like to know the correlation between scrollHeightDiff and scrollTopDiff
                         messagesDiv.scrollTop = adjusted;
                         console.debug("SCROLL: adjusted: ", {
                             ...keyMeasurements(),

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -116,12 +116,6 @@
         }, options);
     });
 
-    function expandDeletedMessages(ev: CustomEvent<{ scrollTop: number; scrollHeight: number }>) {
-        tick().then(() => {
-            chatEventList?.adjust(ev.detail.scrollHeight, ev.detail.scrollTop);
-        });
-    }
-
     function retrySend(ev: CustomEvent<EventWrapper<Message>>): void {
         client.retrySendMessage(chat.chatId, ev.detail, events, undefined);
     }
@@ -429,7 +423,6 @@
                         on:upgrade
                         on:forward
                         on:retrySend={retrySend}
-                        on:expandDeletedMessages={expandDeletedMessages}
                         event={evt} />
                 {/each}
             {/each}

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -135,12 +135,9 @@
         chatEventList?.scrollToMessageIndex(index, false);
     }
 
-    export function scrollToMessageIndex(
-        index: number,
-        preserveFocus: boolean,
-        loadWindowIfMissing: boolean = true
-    ) {
-        chatEventList?.scrollToMessageIndex(index, preserveFocus, loadWindowIfMissing);
+    export function scrollToMessageIndex(index: number, preserveFocus: boolean) {
+        console.debug("SCROLL: currentChatMessages: selecting index", index);
+        chatEventList?.scrollToMessageIndex(index, preserveFocus);
     }
 
     function replyTo(ev: CustomEvent<EnhancedReplyContext>) {
@@ -195,9 +192,13 @@
 
     $: expandedDeletedMessages = client.expandedDeletedMessages;
 
-    $: groupedEvents = client
-        .groupEvents(events, user.userId, $expandedDeletedMessages, groupInner(filteredProposals))
-        .reverse();
+    $: groupedEvents = client.groupEvents(
+        events,
+        user.userId,
+        $expandedDeletedMessages,
+        groupInner(filteredProposals)
+    );
+    // .reverse();
 
     $: {
         if (chat.chatId !== currentChatId) {
@@ -365,6 +366,22 @@
     bind:initialised
     bind:messagesDiv
     bind:messagesDivHeight>
+    {#if showAvatar}
+        {#if $isProposalGroup}
+            <ProposalBot />
+        {:else if chat.kind === "group_chat"}
+            <InitialGroupMessage group={chat} noVisibleEvents={events.length === 0} />
+        {:else if client.isOpenChatBot(chat.them)}
+            <Robot />
+        {:else}
+            <div class="big-avatar">
+                <Avatar
+                    url={client.userAvatarUrl($userStore[chat.them])}
+                    userId={chat.them}
+                    size={AvatarSize.Large} />
+            </div>
+        {/if}
+    {/if}
     {#each groupedEvents as dayGroup, _di (dateGroupKey(dayGroup))}
         <div class="day-group">
             <div class="date-label">
@@ -418,22 +435,6 @@
             {/each}
         </div>
     {/each}
-    {#if showAvatar}
-        {#if $isProposalGroup}
-            <ProposalBot />
-        {:else if chat.kind === "group_chat"}
-            <InitialGroupMessage group={chat} noVisibleEvents={events.length === 0} />
-        {:else if client.isOpenChatBot(chat.them)}
-            <Robot />
-        {:else}
-            <div class="big-avatar">
-                <Avatar
-                    url={client.userAvatarUrl($userStore[chat.them])}
-                    userId={chat.them}
-                    size={AvatarSize.Large} />
-            </div>
-        {/if}
-    {/if}
 </ChatEventList>
 
 <style type="text/scss">

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -118,14 +118,7 @@
 
     function expandDeletedMessages(ev: CustomEvent<{ scrollTop: number; scrollHeight: number }>) {
         tick().then(() => {
-            if (messagesDiv) {
-                // TODO - fix this
-                // expectedScrollTop = undefined;
-                // const diff = (messagesDiv?.scrollHeight ?? 0) - ev.detail.scrollHeight;
-                // interruptScroll(() => {
-                //     messagesDiv?.scrollTo({ top: ev.detail.scrollTop - diff, behavior: "auto" });
-                // });
-            }
+            chatEventList?.adjust(ev.detail.scrollHeight, ev.detail.scrollTop);
         });
     }
 

--- a/frontend/app/src/components/home/RightPanel.svelte
+++ b/frontend/app/src/components/home/RightPanel.svelte
@@ -125,7 +125,7 @@
 
     function closeThread(_ev: CustomEvent<string>) {
         popHistory();
-        page.replace(removeQueryStringParam("open"));
+        page.show(removeQueryStringParam("open"));
     }
 
     function findMessage(

--- a/frontend/app/src/components/home/pinned/PinnedMessages.svelte
+++ b/frontend/app/src/components/home/pinned/PinnedMessages.svelte
@@ -50,9 +50,9 @@
                     } else {
                         messages = {
                             kind: "success",
-                            data: client
-                                .groupMessagesByDate(resp.events.sort((a, b) => a.index - b.index))
-                                .reverse(),
+                            data: client.groupMessagesByDate(
+                                resp.events.sort((a, b) => a.index - b.index)
+                            ),
                         };
 
                         if (unread) {

--- a/frontend/app/src/components/home/thread/Thread.svelte
+++ b/frontend/app/src/components/home/thread/Thread.svelte
@@ -65,9 +65,11 @@
     $: expandedDeletedMessages = client.expandedDeletedMessages;
     $: atRoot = $threadEvents.length === 0 || $threadEvents[0]?.index === 0;
     $: events = atRoot ? [rootEvent, ...$threadEvents] : $threadEvents;
-    $: messages = client
-        .groupEvents(events, user.userId, $expandedDeletedMessages)
-        .reverse() as EventWrapper<Message>[][][];
+    $: messages = client.groupEvents(
+        events,
+        user.userId,
+        $expandedDeletedMessages
+    ) as EventWrapper<Message>[][][];
     $: readonly = client.isChatReadOnly(chat.chatId);
     $: selectedThreadKey = client.selectedThreadKey;
     $: thread = rootEvent.event.thread;

--- a/frontend/app/src/i18n/en.json
+++ b/frontend/app/src/i18n/en.json
@@ -729,5 +729,6 @@
         "expiryMessage": "Your diamond membership expires {relative} ",
         "extendTo": " Extend to ",
         "cannotExtend": "You can only extend your membership within three months of expiry"
-    }
+    },
+    "loadMore": "Load more"
 }

--- a/frontend/app/src/styles/mixins.scss
+++ b/frontend/app/src/styles/mixins.scss
@@ -448,10 +448,10 @@ $shadow-level-3: 2px 6px 12px 0 rgba(25, 25, 25, 0.55);
     background-color: var(--panel-bg);
     padding: $sp3 $sp4;
     overflow-x: hidden;
-    overscroll-behavior-y: contain;
+    // overscroll-behavior-y: contain;
     position: relative;
-    display: flex;
-    flex-direction: column-reverse;
+    // display: flex;
+    // flex-direction: column-reverse;
 
     @include nice-scrollbar();
 

--- a/frontend/openchat-agent/src/constants.ts
+++ b/frontend/openchat-agent/src/constants.ts
@@ -1,6 +1,5 @@
-export const MAX_MESSAGES = 50;
-export const MAX_EVENTS = 150;
-export const EVENT_PAGE_SIZE = 50;
+export const MAX_MESSAGES = 100;
+export const MAX_EVENTS = 500;
 export const MAX_MISSING = 30;
 export const OPENCHAT_BOT_USER_ID = "zzyk3-openc-hatbo-tq7my-cai";
 export const OPENCHAT_BOT_USERNAME = "OpenChatBot";

--- a/frontend/openchat-agent/src/services/group/group.client.ts
+++ b/frontend/openchat-agent/src/services/group/group.client.ts
@@ -205,7 +205,7 @@ export class GroupClient extends CandidService implements IGroupClient {
         const args = {
             thread_root_message_index: apiOptional(identity, threadRootMessageIndex),
             max_messages: MAX_MESSAGES,
-            max_events: 500,
+            max_events: MAX_EVENTS,
             ascending,
             start_index: startIndex,
             invite_code: apiOptional(textToCode, this.inviteCode),

--- a/frontend/openchat-agent/src/utils/caching.spec.ts
+++ b/frontend/openchat-agent/src/utils/caching.spec.ts
@@ -1,0 +1,85 @@
+import { processCachedEvents } from "./caching";
+
+describe("processCachedEvents", () => {
+    const cachedEvents = () => [
+        { index: 0, event: { kind: "message" } },
+        { index: 1, event: { kind: "message" } },
+        { index: 2, event: { kind: "message" } },
+        { index: 3, event: { kind: "message" } },
+        { index: 4, event: { kind: "message" } },
+        { index: 5, event: { kind: "message" } },
+    ];
+    function removeIdxs(
+        events: { index: number; event: { kind: string } }[],
+        idxs: number[]
+    ): { index: number; event: { kind: string } }[] {
+        return events.filter((e) => !idxs.includes(e.index));
+    }
+
+    function tests(ascending: boolean) {
+        test("no cached events", () => {
+            const [events, missing] = processCachedEvents(0, 100, ascending, []);
+            expect(events).toEqual([]);
+            expect(missing.size).toEqual(101);
+        });
+
+        test("events are in index order", () => {
+            const [events, _] = processCachedEvents(0, 5, ascending, cachedEvents());
+            for (let i = 0; i < 6; i++) {
+                expect(events[i].index).toEqual(i);
+            }
+        });
+
+        test("no missing events", () => {
+            const [events, missing] = processCachedEvents(0, 5, ascending, cachedEvents());
+            expect(events.length).toEqual(6);
+            expect(missing.size).toEqual(0);
+        });
+        test("missing last", () => {
+            const [events, missing] = processCachedEvents(
+                0,
+                5,
+                ascending,
+                removeIdxs(cachedEvents(), [5])
+            );
+            expect(events.length).toEqual(5);
+            expect(missing.size).toEqual(1);
+        });
+        test("missing first", () => {
+            const [events, missing] = processCachedEvents(
+                0,
+                5,
+                ascending,
+                removeIdxs(cachedEvents(), [0])
+            );
+            expect(events.length).toEqual(5);
+            expect(missing.size).toEqual(1);
+        });
+        test("missing middle", () => {
+            const [events, missing] = processCachedEvents(
+                0,
+                5,
+                ascending,
+                removeIdxs(cachedEvents(), [1, 2, 3, 4])
+            );
+            expect(events.length).toEqual(2);
+            expect(missing.size).toEqual(4);
+        });
+        test("one cached event", () => {
+            const [events, missing] = processCachedEvents(
+                0,
+                5,
+                ascending,
+                removeIdxs(cachedEvents(), [0, 1, 2, 4, 5])
+            );
+            expect(events.length).toEqual(1);
+            expect(missing.size).toEqual(5);
+        });
+    }
+    describe("descending", () => {
+        tests(false);
+    });
+    describe("ascending", () => {
+        tests(true);
+    });
+});

--- a/frontend/openchat-agent/src/utils/caching.spec.ts
+++ b/frontend/openchat-agent/src/utils/caching.spec.ts
@@ -1,22 +1,71 @@
-import { processCachedEvents } from "./caching";
+import { MAX_EVENTS, MAX_MESSAGES } from "../constants";
+import { processCachedEvents, processCachedEventsWindow } from "./caching";
+
+function largeTest() {
+    const events = [];
+    for (let i = 100; i < MAX_EVENTS; i++) {
+        const kind = i < MAX_MESSAGES + 100 ? "message" : "reaction";
+        events.push({ index: i, event: { kind } });
+    }
+    return events;
+}
+
+const cachedEvents = (from: number, to: number) => {
+    const events = [];
+    for (let i = from; i <= to; i++) {
+        events.push({ index: i, event: { kind: "message" } });
+    }
+    return events;
+};
+
+function removeIdxs(
+    events: { index: number; event: { kind: string } }[],
+    idxs: number[]
+): { index: number; event: { kind: string } }[] {
+    return events.filter((e) => !idxs.includes(e.index));
+}
+
+describe("processCachedEventsWindow", () => {
+    test("no missing events, even range", () => {
+        const [events, missing] = processCachedEventsWindow(0, 5, 3, cachedEvents(0, 5));
+        expect(events.length).toEqual(6);
+        expect(missing.size).toEqual(0);
+    });
+    test("no missing events, odd range", () => {
+        const [events, missing] = processCachedEventsWindow(1, 5, 3, cachedEvents(1, 5));
+        expect(events.length).toEqual(5);
+        expect(missing.size).toEqual(0);
+    });
+    test("odd range, missing middle", () => {
+        const [events, missing] = processCachedEventsWindow(
+            1,
+            5,
+            2,
+            removeIdxs(cachedEvents(1, 5), [3])
+        );
+        expect(events.length).toEqual(4);
+        expect(missing.size).toEqual(1);
+    });
+    test("hit limit early", () => {
+        const [events, missing] = processCachedEventsWindow(100, MAX_EVENTS - 1, 300, largeTest());
+        expect(events.length).toEqual(400);
+        expect(missing.size).toEqual(0);
+    });
+});
 
 describe("processCachedEvents", () => {
-    const cachedEvents = () => [
-        { index: 0, event: { kind: "message" } },
-        { index: 1, event: { kind: "message" } },
-        { index: 2, event: { kind: "message" } },
-        { index: 3, event: { kind: "message" } },
-        { index: 4, event: { kind: "message" } },
-        { index: 5, event: { kind: "message" } },
-    ];
-    function removeIdxs(
-        events: { index: number; event: { kind: string } }[],
-        idxs: number[]
-    ): { index: number; event: { kind: string } }[] {
-        return events.filter((e) => !idxs.includes(e.index));
-    }
-
     function tests(ascending: boolean) {
+        test("hit message limit early", () => {
+            const [events, missing] = processCachedEvents(
+                100,
+                MAX_EVENTS - 1,
+                ascending,
+                largeTest()
+            );
+            expect(events.length).toEqual(ascending ? 100 : 400);
+            expect(missing.size).toEqual(0);
+        });
+
         test("no cached events", () => {
             const [events, missing] = processCachedEvents(0, 100, ascending, []);
             expect(events).toEqual([]);
@@ -24,14 +73,14 @@ describe("processCachedEvents", () => {
         });
 
         test("events are in index order", () => {
-            const [events, _] = processCachedEvents(0, 5, ascending, cachedEvents());
+            const [events, _] = processCachedEvents(0, 5, ascending, cachedEvents(0, 5));
             for (let i = 0; i < 6; i++) {
                 expect(events[i].index).toEqual(i);
             }
         });
 
         test("no missing events", () => {
-            const [events, missing] = processCachedEvents(0, 5, ascending, cachedEvents());
+            const [events, missing] = processCachedEvents(0, 5, ascending, cachedEvents(0, 5));
             expect(events.length).toEqual(6);
             expect(missing.size).toEqual(0);
         });
@@ -40,7 +89,7 @@ describe("processCachedEvents", () => {
                 0,
                 5,
                 ascending,
-                removeIdxs(cachedEvents(), [5])
+                removeIdxs(cachedEvents(0, 5), [5])
             );
             expect(events.length).toEqual(5);
             expect(missing.size).toEqual(1);
@@ -50,7 +99,7 @@ describe("processCachedEvents", () => {
                 0,
                 5,
                 ascending,
-                removeIdxs(cachedEvents(), [0])
+                removeIdxs(cachedEvents(0, 5), [0])
             );
             expect(events.length).toEqual(5);
             expect(missing.size).toEqual(1);
@@ -60,7 +109,7 @@ describe("processCachedEvents", () => {
                 0,
                 5,
                 ascending,
-                removeIdxs(cachedEvents(), [1, 2, 3, 4])
+                removeIdxs(cachedEvents(0, 5), [1, 2, 3, 4])
             );
             expect(events.length).toEqual(2);
             expect(missing.size).toEqual(4);
@@ -70,7 +119,7 @@ describe("processCachedEvents", () => {
                 0,
                 5,
                 ascending,
-                removeIdxs(cachedEvents(), [0, 1, 2, 4, 5])
+                removeIdxs(cachedEvents(0, 5), [0, 1, 2, 4, 5])
             );
             expect(events.length).toEqual(1);
             expect(missing.size).toEqual(5);

--- a/frontend/openchat-agent/src/utils/chat.spec.ts
+++ b/frontend/openchat-agent/src/utils/chat.spec.ts
@@ -1,9 +1,0 @@
-import { enoughVisibleMessages } from "./chat";
-
-// FIXME - we can't test this because it uses an fn imported from shared which we have to stub for now
-describe.skip("enough visible messages", () => {
-    test("returns false when there are no messages", () => {
-        console.log("hello there");
-        expect(enoughVisibleMessages(true, [0, 1000], [])).toBe(false);
-    });
-});

--- a/frontend/openchat-agent/src/utils/chat.ts
+++ b/frontend/openchat-agent/src/utils/chat.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     ChatEvent,
     ChatMetrics,
     ChatSummary,
@@ -12,14 +12,12 @@ import {
     GroupChatSummaryUpdates,
     GroupSubtype,
     GroupSubtypeUpdate,
-    IndexRange,
     Member,
     Mention,
     Message,
     ThreadRead,
     ThreadSyncDetails,
     ThreadSyncDetailsUpdates,
-    eventIsVisible,
     GroupCanisterGroupChatSummary,
     GroupCanisterGroupChatSummaryUpdates,
     UserCanisterGroupChatSummary,
@@ -32,7 +30,7 @@ import { toRecord } from "./list";
 import { applyOptionUpdate, mapOptionUpdate } from "./mapping";
 import Identicon from "identicon.js";
 import md5 from "md5";
-import { EVENT_PAGE_SIZE, OPENCHAT_BOT_AVATAR_URL, OPENCHAT_BOT_USER_ID } from "../constants";
+import { OPENCHAT_BOT_AVATAR_URL, OPENCHAT_BOT_USER_ID } from "../constants";
 
 // this is used to merge both the overall list of chats with updates and also the list of participants
 // within a group chat
@@ -497,23 +495,6 @@ export function emptyChatMetrics(): ChatMetrics {
         polls: 0,
         reactions: 0,
     };
-}
-
-export function enoughVisibleMessages(
-    ascending: boolean,
-    [minIndex, maxIndex]: IndexRange,
-    events: EventWrapper<ChatEvent>[]
-): boolean {
-    const filtered = events.filter(eventIsVisible);
-    if (filtered.length >= EVENT_PAGE_SIZE) {
-        return true;
-    } else if (ascending) {
-        // if there are no more events then we have enough by definition
-        return events[events.length - 1]?.index >= maxIndex;
-    } else {
-        // if there are no previous events then we have enough by definition
-        return events[0].index <= minIndex;
-    }
 }
 
 export function nextIndex(

--- a/frontend/openchat-client/src/events.ts
+++ b/frontend/openchat-client/src/events.ts
@@ -18,15 +18,15 @@ export class SendMessageFailed extends CustomEvent<boolean> {
     }
 }
 
-export class LoadedPreviousMessages extends Event {
-    constructor() {
-        super("openchat_event");
+export class LoadedPreviousMessages extends CustomEvent<boolean> {
+    constructor(initialising: boolean) {
+        super("openchat_event", { detail: initialising });
     }
 }
 
-export class LoadedPreviousThreadMessages extends Event {
-    constructor() {
-        super("openchat_event");
+export class LoadedPreviousThreadMessages extends CustomEvent<boolean> {
+    constructor(initialising: boolean) {
+        super("openchat_event", { detail: initialising });
     }
 }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -59,7 +59,7 @@ import {
 } from "./utils/user";
 import { rtcConnectionsManager } from "./utils/rtcConnectionsManager";
 import { showTrace } from "./utils/profiling";
-import { CachePrimer } from "./utils/cachePrimer";
+import type { CachePrimer } from "./utils/cachePrimer";
 import { Poller } from "./utils/poller";
 import {
     idbAuthClientStore,
@@ -482,7 +482,7 @@ export class OpenChat extends EventTarget {
         this._workerApi = new OpenChatAgentWorker(this.config);
         this._workerApi.addEventListener("openchat_event", (ev) => this.handleAgentEvent(ev));
         await this._workerApi.ready;
-        this._cachePrimer = new CachePrimer(this._workerApi);
+        // this._cachePrimer = new CachePrimer(this._workerApi);
         this.api.loadFailedMessages().then((res) => failedMessagesStore.initialise(res));
         this.api
             .getCurrentUser()

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1828,6 +1828,8 @@ export class OpenChat extends EventTarget {
             return false;
         }
 
+        console.log("Events loaded: ", eventsResponse.events);
+
         await this.handleEventsResponse(serverChat, eventsResponse);
         // We may have loaded messages which are more recent than what the chat summary thinks is the latest message,
         // if so, we update the chat summary to show the correct latest message.
@@ -2866,11 +2868,10 @@ export class OpenChat extends EventTarget {
     }
 
     getSnsProposalTally(snsGovernanceCanisterId: string, proposalId: bigint): Promise<Tally> {
-        return this.api.getSnsProposalTally(snsGovernanceCanisterId, proposalId)
-            .then((tally) => {
-                proposalTallies.setTally(snsGovernanceCanisterId, proposalId, tally);
-                return tally;
-            })
+        return this.api.getSnsProposalTally(snsGovernanceCanisterId, proposalId).then((tally) => {
+            proposalTallies.setTally(snsGovernanceCanisterId, proposalId, tally);
+            return tally;
+        });
     }
 
     getRecommendedGroups(): Promise<GroupChatSummary[]> {
@@ -3324,7 +3325,9 @@ export class OpenChat extends EventTarget {
                     pinnedChatsStore.set(chatsResponse.pinnedChats);
                 }
 
-                myServerChatSummariesStore.set(toRecord(chatsResponse.chatSummaries, (chat) => chat.chatId));
+                myServerChatSummariesStore.set(
+                    toRecord(chatsResponse.chatSummaries, (chat) => chat.chatId)
+                );
 
                 if (Object.keys(this._liveState.uninitializedDirectChats).length > 0) {
                     for (const chat of chatsResponse.chatSummaries) {

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1546,7 +1546,7 @@ export class OpenChat extends EventTarget {
                     this.loadDetails(selectedChat);
                 });
             } else {
-                this.loadPreviousMessages(chatId).then(() => {
+                this.loadPreviousMessages(chatId, undefined, true).then(() => {
                     this.loadDetails(selectedChat);
                 });
             }
@@ -1567,7 +1567,7 @@ export class OpenChat extends EventTarget {
         this.clearThreadEvents();
         selectedThreadRootEvent.set(threadRootEvent);
         if (!initiating && this._liveState.selectedChatId !== undefined) {
-            this.loadPreviousMessages(this._liveState.selectedChatId, threadRootEvent);
+            this.loadPreviousMessages(this._liveState.selectedChatId, threadRootEvent, true);
         }
         this.dispatchEvent(new ThreadSelected(threadRootEvent, initiating));
     }
@@ -1588,7 +1588,8 @@ export class OpenChat extends EventTarget {
         startIndex: number,
         ascending: boolean,
         threadRootMessageIndex: number,
-        clearEvents: boolean
+        clearEvents: boolean,
+        initialLoad = false
     ): Promise<void> {
         const chat = this._liveState.chatSummaries[chatId];
 
@@ -1640,7 +1641,7 @@ export class OpenChat extends EventTarget {
             if (ascending) {
                 this.dispatchEvent(new LoadedNewThreadMessages(false));
             } else {
-                this.dispatchEvent(new LoadedPreviousThreadMessages());
+                this.dispatchEvent(new LoadedPreviousThreadMessages(initialLoad));
             }
         }
     }
@@ -1716,7 +1717,8 @@ export class OpenChat extends EventTarget {
 
     async loadPreviousMessages(
         chatId: string,
-        threadRootEvent?: EventWrapper<Message>
+        threadRootEvent?: EventWrapper<Message>,
+        initialLoad = false
     ): Promise<void> {
         const serverChat = this._liveState.serverChatSummaries[chatId];
 
@@ -1734,7 +1736,8 @@ export class OpenChat extends EventTarget {
                 index,
                 ascending,
                 threadRootEvent.event.messageIndex,
-                false
+                false,
+                initialLoad
             );
         }
 
@@ -1750,7 +1753,7 @@ export class OpenChat extends EventTarget {
 
         await this.handleEventsResponse(serverChat, eventsResponse);
 
-        this.dispatchEvent(new LoadedPreviousMessages());
+        this.dispatchEvent(new LoadedPreviousMessages(initialLoad));
         return;
     }
 

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -482,7 +482,7 @@ export class OpenChat extends EventTarget {
         this._workerApi = new OpenChatAgentWorker(this.config);
         this._workerApi.addEventListener("openchat_event", (ev) => this.handleAgentEvent(ev));
         await this._workerApi.ready;
-        // this._cachePrimer = new CachePrimer(this._workerApi);
+        this._cachePrimer = new CachePrimer(this._workerApi);
         this.api.loadFailedMessages().then((res) => failedMessagesStore.initialise(res));
         this.api
             .getCurrentUser()

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -59,7 +59,7 @@ import {
 } from "./utils/user";
 import { rtcConnectionsManager } from "./utils/rtcConnectionsManager";
 import { showTrace } from "./utils/profiling";
-import type { CachePrimer } from "./utils/cachePrimer";
+import { CachePrimer } from "./utils/cachePrimer";
 import { Poller } from "./utils/poller";
 import {
     idbAuthClientStore,

--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -1870,10 +1870,7 @@ export class OpenChat extends EventTarget {
         );
     }
 
-    moreNewMessagesAvailable(
-        chatId: string,
-        threadRootEvent?: EventWrapper<Message> /* TODO - make this work for threads */
-    ): boolean {
+    moreNewMessagesAvailable(chatId: string, threadRootEvent?: EventWrapper<Message>): boolean {
         if (threadRootEvent !== undefined && threadRootEvent.event.thread !== undefined) {
             return (
                 (this.confirmedThreadUpToEventIndex() ?? -1) <


### PR DESCRIPTION
This simplifies a few things and complicates a few things. The motivation is to improve the behaviour when scrolling forwards in time to newer messages which is not good on iOS safari (and firefox). When we invert, we move the problem to the other direction. The issue still exists, but this way round it doesn't affect the more common use case. 

Also fix the caching layer so that it actually retrieves the correct number of events. This improves the performance of chats with lots of non-message events. This will hopefully be further improved by merging some non-message events. 