### PR TITLE
couple of fixes for closing thread

### DIFF
--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -210,7 +210,7 @@
 
     function scrollToMention(mention: Mention | undefined) {
         if (mention !== undefined) {
-            scrollToMessageIndex(mention.messageIndex, false);
+            scrollToMessageIndex(chat.chatId, mention.messageIndex, false);
         }
     }
 
@@ -248,9 +248,13 @@
     }
 
     export async function scrollToMessageIndex(
+        chatId: string,
         index: number,
         preserveFocus: boolean
     ): Promise<void> {
+        // it is possible for the chat to change while this function is recursing so double check
+        if (chatId !== chat.chatId) return Promise.resolve();
+
         if (index < 0) {
             setFocusMessageIndex(undefined);
             return Promise.resolve();
@@ -264,7 +268,7 @@
             await scrollToElement(element);
             checkIfTargetMessageHasAThread(index);
             if (await loadMoreIfRequired(false, true)) {
-                return scrollToMessageIndex(index, preserveFocus);
+                return scrollToMessageIndex(chatId, index, preserveFocus);
             } else {
                 if (!preserveFocus) {
                     window.setTimeout(() => {
@@ -275,8 +279,8 @@
                 return Promise.resolve();
             }
         } else {
-            await client.loadEventWindow(chat.chatId, index, threadRootEvent);
-            return scrollToMessageIndex(index, preserveFocus);
+            await client.loadEventWindow(chatId, index, threadRootEvent);
+            return scrollToMessageIndex(chatId, index, preserveFocus);
         }
     }
 
@@ -287,7 +291,7 @@
         if (messageIndex === undefined || initialLoad === false) return;
         await tick();
         initialised = true;
-        await scrollToMessageIndex(messageIndex, false);
+        await scrollToMessageIndex(chat.chatId, messageIndex, false);
     }
 
     async function onLoadedPreviousMessages(initialLoad: boolean) {
@@ -356,7 +360,7 @@
     }
 
     async function loadIndexThenScrollToBottom(messageIndex: number) {
-        await scrollToMessageIndex(messageIndex, false);
+        await scrollToMessageIndex(chat.chatId, messageIndex, false);
         await scrollBottom();
     }
 

--- a/frontend/app/src/components/home/ChatMessage.svelte
+++ b/frontend/app/src/components/home/ChatMessage.svelte
@@ -162,6 +162,7 @@
     });
 
     function chatWithUser() {
+        closeUserProfile();
         dispatch("chatWith", msg.sender);
     }
 

--- a/frontend/app/src/components/home/CurrentChatMessages.svelte
+++ b/frontend/app/src/components/home/CurrentChatMessages.svelte
@@ -126,11 +126,11 @@
 
     function doGoToMessageIndex(index: number): void {
         page(`/${chat.chatId}`);
-        chatEventList?.scrollToMessageIndex(index, false);
+        chatEventList?.scrollToMessageIndex(chat.chatId, index, false);
     }
 
     export function scrollToMessageIndex(index: number, preserveFocus: boolean) {
-        chatEventList?.scrollToMessageIndex(index, preserveFocus);
+        chatEventList?.scrollToMessageIndex(chat.chatId, index, preserveFocus);
     }
 
     function replyTo(ev: CustomEvent<EnhancedReplyContext>) {

--- a/frontend/app/src/components/home/thread/Thread.svelte
+++ b/frontend/app/src/components/home/thread/Thread.svelte
@@ -243,7 +243,7 @@
 
     function goToMessageIndex(index: number) {
         focusMessageIndex = index;
-        chatEventList?.scrollToMessageIndex(index, false);
+        chatEventList?.scrollToMessageIndex(chat.chatId, index, false);
     }
 
     function onGoToMessageIndex(
@@ -345,7 +345,6 @@
                             on:replyPrivatelyTo
                             on:replyTo={replyTo}
                             on:editEvent={() => editEvent(evt)}
-                            on:chatWith
                             on:replyTo={replyTo}
                             on:replyPrivatelyTo
                             on:upgrade


### PR DESCRIPTION
If you choose to chat with a thread participant from their profile we were not closing the thread. Also noticed a possible case were recursion in `scrollToMessageIndex` would not terminate if the chat changes during the recursion. 