### PR TITLE
Fix thread routing

### DIFF
--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -304,7 +304,10 @@
     function checkIfTargetMessageHasAThread(index: number) {
         const msgEvent = findMessageEvent(index);
         if (msgEvent && threadRootEvent === undefined) {
-            if (msgEvent.event.thread !== undefined && $pathParams.open) {
+            if (
+                msgEvent.event.thread !== undefined &&
+                ($pathParams.open || $pathParams.threadMessageIndex !== undefined)
+            ) {
                 client.openThread(msgEvent, false);
             } else {
                 client.closeThread();

--- a/frontend/app/src/components/home/Home.svelte
+++ b/frontend/app/src/components/home/Home.svelte
@@ -171,7 +171,11 @@
         }
     }
 
-    async function newChatSelected(chatId: string, messageIndex?: number): Promise<void> {
+    async function newChatSelected(
+        chatId: string,
+        messageIndex?: number,
+        threadMessageIndex?: number
+    ): Promise<void> {
         let chat = $chatSummariesStore[chatId];
 
         // if this is an unknown chat let's preview it
@@ -201,7 +205,7 @@
         // if it's a known chat let's select it
         closeNotificationsForChat(chat.chatId);
         $eventListScrollTop = undefined;
-        client.setSelectedChat(chat.chatId, messageIndex);
+        client.setSelectedChat(chat.chatId, messageIndex, threadMessageIndex);
         resetRightPanel();
         hotGroups = { kind: "idle" };
     }
@@ -243,7 +247,11 @@
                     // if the chat in the url is different from the chat we already have selected
                     if (pathParams.chatId !== $selectedChatId?.toString()) {
                         console.log("PathParams: ", pathParams);
-                        newChatSelected(pathParams.chatId, pathParams.messageIndex);
+                        newChatSelected(
+                            pathParams.chatId,
+                            pathParams.messageIndex,
+                            pathParams.threadMessageIndex
+                        );
                     } else {
                         // if the chat in the url is *the same* as the selected chat
                         // *and* if we have a messageIndex specified in the url

--- a/frontend/app/src/components/home/RightPanel.svelte
+++ b/frontend/app/src/components/home/RightPanel.svelte
@@ -24,8 +24,9 @@
     import { numberOfColumns } from "stores/layout";
     import Thread from "./thread/Thread.svelte";
     import ProposalGroupFilters from "./ProposalGroupFilters.svelte";
-    import { removeQueryStringParam } from "../../utils/urls";
+    import { removeQueryStringParam, removeThreadMessageIndex } from "../../utils/urls";
     import { logger } from "../../utils/logging";
+    import { pathParams } from "../../routes";
     import page from "page";
 
     const dispatch = createEventDispatcher();
@@ -123,9 +124,16 @@
         }
     }
 
+    function stripThreadFromUrl(path: string) {
+        if ($pathParams.threadMessageIndex !== undefined) {
+            return removeThreadMessageIndex($pathParams.threadMessageIndex, path);
+        }
+        return path;
+    }
+
     function closeThread(_ev: CustomEvent<string>) {
         popHistory();
-        page.replace(removeQueryStringParam("open"));
+        page.replace(stripThreadFromUrl(removeQueryStringParam("open")));
     }
 
     function findMessage(

--- a/frontend/app/src/components/home/thread/Thread.svelte
+++ b/frontend/app/src/components/home/thread/Thread.svelte
@@ -31,7 +31,6 @@
     export let chat: ChatSummary;
 
     let chatEventList: ChatEventList | undefined;
-    let focusMessageIndex: number | undefined = undefined;
     let observer: IntersectionObserver = new IntersectionObserver(() => {});
     let pollBuilder: PollBuilder;
     let giphySelector: GiphySelector;
@@ -43,6 +42,7 @@
     let messagesDivHeight: number;
     let previousLatestEventIndex: number | undefined = undefined;
 
+    $: focusMessageIndex = client.focusThreadMessageIndex;
     $: currentChatMembers = client.currentChatMembers;
     $: lastCryptoSent = client.lastCryptoSent;
     $: draftThreadMessages = client.draftThreadMessages;
@@ -242,7 +242,6 @@
     }
 
     function goToMessageIndex(index: number) {
-        focusMessageIndex = index;
         chatEventList?.scrollToMessageIndex(chat.chatId, index, false);
     }
 
@@ -290,7 +289,7 @@
     {readonly}
     unreadMessages={0}
     firstUnreadMention={undefined}
-    setFocusMessageIndex={(idx) => (focusMessageIndex = idx)}
+    setFocusMessageIndex={(idx) => client.setFocusThreadMessageIndex(chat.chatId, idx)}
     footer
     {events}
     {chat}
@@ -325,7 +324,7 @@
                             readByMe
                             {observer}
                             focused={evt.event.kind === "message" &&
-                                focusMessageIndex === evt.event.messageIndex}
+                                $focusMessageIndex === evt.event.messageIndex}
                             {readonly}
                             {threadRootMessage}
                             pinned={false}

--- a/frontend/app/src/utils/urls.ts
+++ b/frontend/app/src/utils/urls.ts
@@ -20,6 +20,11 @@ export function addQueryStringParam(name: string, val: string): string {
     return [...qs.keys()].length > 0 ? `${path}?${qs}` : path;
 }
 
+export function removeThreadMessageIndex(threadMessageIndex: number, path: string): string {
+    const re = new RegExp(`(\\/${threadMessageIndex})(\\?.*)?$`);
+    return path.replace(re, "");
+}
+
 export function removeQueryStringParam(name: string): string {
     const path = window.location.pathname;
     const qs = new URLSearchParams(window.location.search);

--- a/frontend/openchat-client/src/agentWorker.ts
+++ b/frontend/openchat-client/src/agentWorker.ts
@@ -814,17 +814,14 @@ export class OpenChatAgentWorker extends EventTarget {
         });
     }
 
-    getSnsProposalTally(
-        snsGovernanceCanisterId: string,
-        proposalId: bigint
-    ): Promise<Tally> {
+    getSnsProposalTally(snsGovernanceCanisterId: string, proposalId: bigint): Promise<Tally> {
         return this.sendRequest({
             kind: "getSnsProposalTally",
             payload: {
                 snsGovernanceCanisterId,
                 proposalId,
-            }
-        })
+            },
+        });
     }
 
     listNervousSystemFunctions(

--- a/frontend/openchat-client/src/liveState.ts
+++ b/frontend/openchat-client/src/liveState.ts
@@ -24,6 +24,7 @@ import {
     chatSummariesListStore,
     threadsByChatStore,
     focusMessageIndex,
+    focusThreadMessageIndex,
     threadEvents,
     selectedThreadKey,
     threadsFollowedByMeStore,
@@ -63,6 +64,7 @@ export class LiveState {
     chatSummariesList!: ChatSummary[];
     threadsByChat!: Record<string, ThreadSyncDetails[]>;
     focusMessageIndex: number | undefined;
+    focusThreadMessageIndex: number | undefined;
     threadEvents!: EventWrapper<ChatEvent>[];
     selectedThreadKey: string | undefined;
     threadsFollowedByMe!: Record<string, Set<number>>;
@@ -93,6 +95,7 @@ export class LiveState {
         chatSummariesListStore.subscribe((data) => (this.chatSummariesList = data));
         threadsByChatStore.subscribe((data) => (this.threadsByChat = data));
         focusMessageIndex.subscribe((data) => (this.focusMessageIndex = data));
+        focusThreadMessageIndex.subscribe((data) => (this.focusThreadMessageIndex = data));
         threadEvents.subscribe((data) => (this.threadEvents = data));
         selectedThreadKey.subscribe((data) => (this.selectedThreadKey = data));
         threadsFollowedByMeStore.subscribe((data) => (this.threadsFollowedByMe = data));

--- a/frontend/openchat-push/src/index.ts
+++ b/frontend/openchat-push/src/index.ts
@@ -128,7 +128,7 @@ async function showNotification(notification: Notification): Promise<void> {
         icon = content.image ?? icon;
         path =
             notification.threadRootMessageIndex !== undefined
-                ? `${notification.chatId}/${notification.threadRootMessageIndex}?open=true`
+                ? `${notification.chatId}/${notification.threadRootMessageIndex}/${notification.message.event.messageIndex}?open=true`
                 : `${notification.chatId}/${notification.message.event.messageIndex}`;
         tag = notification.threadRootMessageIndex !== undefined ? path : notification.chatId;
         timestamp = Number(notification.message.timestamp);

--- a/frontend/openchat-shared/src/domain/chat/chat.ts
+++ b/frontend/openchat-shared/src/domain/chat/chat.ts
@@ -891,6 +891,7 @@ export type ChatSpecificState = {
     rules?: GroupRules;
     userIds: Set<string>;
     focusMessageIndex?: number;
+    focusThreadMessageIndex?: number;
     userGroupKeys: Set<string>;
     serverEvents: EventWrapper<ChatEvent>[];
     expandedDeletedMessages: Set<number>;
@@ -1641,10 +1642,7 @@ export type RemoveHotGroupExclusionResponse =
     | "not_authorized"
     | "internal_error";
 
-export type SetGroupUpgradeConcurrencyResponse =
-    | "success"
-    | "not_authorized"
-    | "internal_error";
+export type SetGroupUpgradeConcurrencyResponse = "success" | "not_authorized" | "internal_error";
 
 export type MarkPinnedMessagesReadResponse = "success" | "chat_frozen";
 


### PR DESCRIPTION
Make sure that urls of the form `/chat-id/message-index/thread-message-index` will open the thread and go to the right thread message. 

Make sure that notifications for thread message form the right url. 

fixes #2989 