### PR TITLE
use block markdown if (and only if) we detect multiline codeblock

### DIFF
--- a/frontend/app/src/components/home/Markdown.svelte
+++ b/frontend/app/src/components/home/Markdown.svelte
@@ -138,8 +138,10 @@
             }
 
             pre {
-                padding: toRem(12);
+                padding: toRem(16);
                 overflow-x: auto;
+                border-radius: toRem(12);
+                border: 1px solid rgba(255, 255, 255, 0.1);
             }
 
             blockquote {

--- a/frontend/app/src/components/home/TextContent.svelte
+++ b/frontend/app/src/components/home/TextContent.svelte
@@ -36,10 +36,11 @@
     $: text = truncateText($translationStore.get(Number(messageId)) ?? content.text);
     $: socialVideoMatch = content.text.match(client.youtubeRegex());
     $: twitterLinkMatch = text.match(client.twitterLinkRegex());
+    $: containsCodeBlock = content.text.match(/```([\s\S]*)```/);
 </script>
 
 {#if !socialVideoMatch}
-    <Markdown suppressLinks={pinned} {text} />
+    <Markdown inline={!containsCodeBlock} suppressLinks={pinned} {text} />
     {#if edited}
         <span class="edited-msg">({$_("edited")})</span>
     {/if}


### PR DESCRIPTION
Makes pasting code snippets a lot more friendly. 

<img width="870" alt="image" src="https://user-images.githubusercontent.com/86620/227563867-35108b4e-401a-4f45-9967-3d205894d17c.png">
