### PR TITLE
correct the infinite loop problem

### DIFF
--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -370,7 +370,10 @@
                 // but it's still not clear what to do in this circumstance because we cannot
                 // scroll to this message and there is nothing that we can do about it. So where *do* we scroll?
                 // The *next* message?, the bottom?, nowhere?
-                return scrollBottom();
+                const nextMessage = findElementWithMessageIndex(index + 1);
+                return nextMessage
+                    ? scrollToMessageIndex(chatId, index + 1, preserveFocus, filling)
+                    : scrollBottom();
             }
         }
     }

--- a/frontend/app/src/components/home/ChatEventList.svelte
+++ b/frontend/app/src/components/home/ChatEventList.svelte
@@ -358,9 +358,20 @@
                 return Promise.resolve();
             }
         } else if (!destroyed) {
-            // make sure that we short-circuit recursion when unmounted otherwise ∞ 💥
-            await client.loadEventWindow(chatId, index, threadRootEvent);
-            return scrollToMessageIndex(chatId, index, preserveFocus);
+            // check whether we have already loaded the event we are looking for
+            const loaded = findMessageEvent(index);
+            if (loaded === undefined) {
+                // we must only recurse if we have not already loaded the event, otherwise we will enter an infinite loop
+                await client.loadEventWindow(chatId, index, threadRootEvent);
+                return scrollToMessageIndex(chatId, index, preserveFocus);
+            } else {
+                // if we got here it means that we could not find the DOM element for and event that we
+                // have already loaded. This isn't necessarily an error since a message might have been hidden
+                // but it's still not clear what to do in this circumstance because we cannot
+                // scroll to this message and there is nothing that we can do about it. So where *do* we scroll?
+                // The *next* message?, the bottom?, nowhere?
+                return scrollBottom();
+            }
         }
     }
 

--- a/frontend/app/src/components/home/ReminderBuilder.svelte
+++ b/frontend/app/src/components/home/ReminderBuilder.svelte
@@ -95,12 +95,12 @@
             .then((success) => {
                 if (success) {
                     toastStore.showSuccessToast("reminders.success");
-                    dispatch("close");
                 } else {
                     toastStore.showFailureToast("reminders.failure");
                 }
             })
             .finally(() => (busy = false));
+        dispatch("close");
     }
 </script>
 


### PR DESCRIPTION
The way scrollToMessageIndex currently works is that it looks for the message's dom element and if it doesn't find it it tries to load it and then recurses. 

This can lead to infinite recursion if the message is _hidden_ because even after the message is loaded, the dom element will still not exist. 

Therefore, when we don't find the DOM element, before we recurse, we check whether we have already loaded the message. If we have already loaded it then there is no point recursing. We still can't scroll to the message because it's not there, but recursion is futile at that point so we just scroll to the bottom (which may not be idea - but there isn't really anything better we can do). 