### PR TITLE
prevent preview of frozen groups

### DIFF
--- a/frontend/openchat-client/src/openchat.ts
+++ b/frontend/openchat-client/src/openchat.ts
@@ -690,7 +690,7 @@ export class OpenChat extends EventTarget {
 
     previewChat(chatId: string): Promise<boolean> {
         return this.api.getPublicGroupSummary(chatId).then((maybeChat) => {
-            if (maybeChat === undefined) {
+            if (maybeChat === undefined || maybeChat.frozen) {
                 return false;
             }
             addGroupPreview(maybeChat);


### PR DESCRIPTION
There's not much point in freezing a group if you can still see all of the messages. 