### PR TITLE
Update cache after each updates loop

### DIFF
--- a/frontend/openchat-agent/src/services/openchatAgent.ts
+++ b/frontend/openchat-agent/src/services/openchatAgent.ts
@@ -937,7 +937,7 @@ export class OpenChatAgent extends EventTarget {
         const updatedEvents = getUpdatedEvents(updates.directChatsUpdated, groupUpdates);
 
         return await this.hydrateChatState(state).then((s) => {
-            if (anyUpdates && !anyErrors) {
+            if (!anyErrors) {
                 setCachedChats(this.db, this.principal, s, updatedEvents);
             }
 


### PR DESCRIPTION
Even if there are no updates, we should overwrite the cache to increment the `latestActiveGroupsCheck` timestamp, otherwise we'll keep polling groups unnecessarily due to using an old timestamp.